### PR TITLE
feat: クリップボード・選択テキスト候補挿入を再実装

### DIFF
--- a/GyaimSwift/Sources/Gyaim/GyaimController.swift
+++ b/GyaimSwift/Sources/Gyaim/GyaimController.swift
@@ -13,6 +13,10 @@ class GyaimController: IMKInputController {
     private var searchMode = 0
     private var tmpImageDisplayed = false
     private var bsThrough = false
+    /// Clipboard text captured at input start (valid for 5 seconds after copy).
+    private var clipboardCandidate: String?
+    /// Selected text captured at the moment of first keystroke.
+    private var selectedCandidate: String?
 
     private var ws: WordSearch?
     private var rk = RomaKana()
@@ -63,6 +67,8 @@ class GyaimController: IMKInputController {
         candidates = []
         nthCand = 0
         searchMode = 0
+        clipboardCandidate = nil
+        selectedCandidate = nil
     }
 
     private var converting: Bool {
@@ -218,6 +224,10 @@ class GyaimController: IMKInputController {
             if nthCand > 0 || searchMode > 0 {
                 fix(client: sender)
             }
+            // Capture selected text and clipboard only on the first keystroke of a new input
+            if inputPat.isEmpty {
+                captureExternalCandidates(client: sender)
+            }
             inputPat += eventString
             searchAndShowCands(client: sender)
             searchMode = 0
@@ -226,6 +236,43 @@ class GyaimController: IMKInputController {
 
         showWindow()
         return handled
+    }
+
+    // MARK: - External Candidate Capture
+
+    /// Capture selected text and clipboard at input start.
+    /// Called once when the first printable character is typed.
+    private func captureExternalCandidates(client sender: Any?) {
+        // Capture selected text from the active application
+        if let client = sender as? IMKTextInput {
+            let range = client.selectedRange()
+            if let attrStr = client.attributedSubstring(from: range) {
+                let s = attrStr.string
+                if !s.isEmpty {
+                    selectedCandidate = s
+                    Log.input.info("Captured selected text: \"\(s)\"")
+                }
+            }
+        }
+
+        // Capture clipboard text (only if copied within last 5 seconds)
+        let elapsed = Date().timeIntervalSince(CopyText.time)
+        if elapsed < 5.0 {
+            let text = CopyText.get()
+            if !text.isEmpty {
+                clipboardCandidate = text
+                Log.input.info("Captured clipboard text: \"\(text)\" (age: \(String(format: "%.1f", elapsed))s)")
+            }
+        }
+    }
+
+    /// Check if a string is a valid external candidate (not a Gyazo hash, not a URL).
+    private static func isValidExternalCandidate(_ s: String) -> Bool {
+        let trimmed = s.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty { return false }
+        if ImageManager.isImageCandidate(trimmed) { return false }
+        if trimmed.hasPrefix("http") { return false }
+        return true
     }
 
     // MARK: - Search & Display
@@ -249,6 +296,16 @@ class GyaimController: IMKInputController {
         } else {
             candidates = PerfLog.measure("search(\(inputPat), prefix)", logger: Log.input) {
                 ws.search(query: inputPat, searchMode: searchMode)
+            }
+
+            // Prepend selected text if available
+            if let sel = selectedCandidate, Self.isValidExternalCandidate(sel) {
+                candidates.insert(SearchCandidate(word: sel), at: 0)
+            }
+
+            // Prepend clipboard text if available
+            if let clip = clipboardCandidate, Self.isValidExternalCandidate(clip) {
+                candidates.insert(SearchCandidate(word: clip), at: 0)
             }
 
             // Input pattern itself as first candidate
@@ -365,8 +422,13 @@ class GyaimController: IMKInputController {
             client.insertText(word, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
         }
 
-        // Study logic
-        if let reading = candidate.reading {
+        // Register or study logic
+        let isExternalCandidate = (word == clipboardCandidate || word == selectedCandidate)
+        if isExternalCandidate {
+            // External candidate (clipboard/selected text) → register to user dict
+            ws?.register(word: word, reading: inputPat)
+            Log.input.info("Registered to user dict: \"\(word)\" (reading: \"\(inputPat)\")")
+        } else if let reading = candidate.reading {
             if reading != "ds" {
                 ws?.study(word: word, reading: reading)
             }


### PR DESCRIPTION
## Summary

- オリジナルGyaimの単語登録フロー（コピー/選択テキスト → 第一候補 → 確定でユーザー辞書登録）を再実装
- 旧実装のバグ（`selectedStr` がリセットされず残り続ける問題 #2）を修正
- クリップボード候補はコピーから5秒以内のみ有効

## 旧実装からの改善点

| 問題 | 旧実装 | 新実装 |
|------|--------|--------|
| selectedStr残留 | 毎キー入力時に上書き取得、resetState以外でクリアされない | 入力開始時（最初の1文字目）にのみキャプチャ、resetStateで確実にクリア |
| ゴミ混入 | 入力中に別のテキストが選択されると候補に紛れ込む | 入力開始後はキャプチャしない |

## 動作フロー

1. テキストをCmd-Cでコピー（または選択状態にする）
2. IMEで入力を開始（最初の1文字目で選択テキスト/クリップボードをキャプチャ）
3. クリップボード/選択テキストが候補リストに表示される
4. スペースで候補を選択し確定 → ユーザー辞書（`~/.gyaim/localdict.txt`）に登録

## Test plan

- [x] ビルド成功を確認
- [x] テキストをCmd-Cでコピー → 5秒以内にIME入力開始 → クリップボードテキストが候補に表示される
- [x] 5秒以上経過後にIME入力 → クリップボードテキストは候補に出ない
- [x] テキスト選択状態でIME入力 → 選択テキストが候補に表示される
- [x] 候補からクリップボード/選択テキストを確定 → `~/.gyaim/localdict.txt` に登録される
- [x] 通常の候補確定 → 学習辞書（studydict.txt）に記録される（従来通り）
- [x] URL（`http...`）やGyazoハッシュは候補に挿入されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)