### PR TITLE
fix: IME切替時に未確定テキストを確定する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ Bidirectional romaji-kana conversion with 350+ rules in `rklist`. Includes full-
 - **NSApp.setActivationPolicy** — Use `.accessory` temporarily when opening settings/dict editor windows, revert to `.prohibited` on close
 - **Icon must be 20x20 PDF** for Retina-compatible menu bar display
 - **User data directory**: `~/.gyaim/` (localdict.txt, studydict.txt)
+- **IME切替時の未確定テキスト**: `deactivateServer` で未確定テキストを自動確定する（Mozc/Google日本語入力等と同じ標準動作）。`fix(client: sender)` でクライアントに挿入し、`self.client()` フォールバックで堅牢性を確保
 
 ## Testing
 

--- a/GyaimSwift/Sources/Gyaim/GyaimController.swift
+++ b/GyaimSwift/Sources/Gyaim/GyaimController.swift
@@ -126,9 +126,9 @@ class GyaimController: IMKInputController {
     }
 
     override func deactivateServer(_ sender: Any!) {
-        Log.input.info("IME deactivated")
+        Log.input.info("IME deactivated: committing preedit (converting=\(converting), candidates=\(candidates.count))")
         hideWindow()
-        fix()
+        fix(client: sender)
         ws?.finish()
     }
 
@@ -747,7 +747,8 @@ class GyaimController: IMKInputController {
         let candidateWords = candidates.map(\.word)
         Log.input.info("Fixed: \"\(word)\" (reading: \"\(reading)\", index: \(nthCand)/\(candidates.count), candidates: \(candidateWords))")
 
-        guard let client = sender as? IMKTextInput else {
+        let resolvedClient = (sender as? IMKTextInput) ?? (self.client() as? IMKTextInput)
+        guard let client = resolvedClient else {
             resetState()
             return
         }

--- a/docs/adr/012-commit-preedit-on-deactivation.md
+++ b/docs/adr/012-commit-preedit-on-deactivation.md
@@ -1,0 +1,52 @@
+# ADR-012: IME切替時に未確定テキストを確定する
+
+## Status
+
+Accepted
+
+## Decision
+
+`deactivateServer(_:)` で未確定テキスト（preedit）がある場合、破棄せずクライアントに確定（insertText）する。`fix(client:)` のクライアント解決に `self.client()` フォールバックを追加し、senderがnilでも確定できるようにする。
+
+## Context
+
+Gyaimで文字入力中（未確定状態）にIMEをoffに切り替えると、入力中のテキストが消えてしまう問題があった（Issue #13）。
+
+原因は `deactivateServer(_:)` が `fix()` を引数なしで呼んでいたため、`fix(client:)` 内の `sender as? IMKTextInput` キャストが常に失敗し、`resetState()` でテキストが破棄されていたこと。
+
+## Consideration
+
+### 他IMEの挙動調査
+
+| IME | deactivation時の未確定テキスト |
+|-----|-------------------------------|
+| Mozc / Google日本語入力 | 確定する（`switchModeToDirect:` → `commitText:`） |
+| AzooKey | InputMethodKitサンプルパターンに従い確定 |
+| ATOK | 確定する |
+
+全ての主要日本語IMEは未確定テキストを確定する。破棄するIMEは確認できなかった。これはユーザーの入力を失わないという原則に基づく標準動作である。
+
+### 設定トグルの要否
+
+全IMEが確定を標準動作としているため、設定で無効化する必要はないと判断した。
+
+### 修正方法
+
+`fixAsKana()` で既に使われている `self.client()` フォールバックパターンを `fix(client:)` にも適用する。
+
+```swift
+// fixAsKana() (line 719) の既存パターン
+let resolvedClient = (sender as? IMKTextInput) ?? (self.client() as? IMKTextInput)
+```
+
+## Consequences
+
+- IME切替時に未確定テキストが確定され、ユーザーの入力が失われなくなる
+- Mozc等の他IMEと同じ標準動作になり、ユーザーの期待に沿う
+- `fix(client:)` が `self.client()` フォールバックを持つことで、sender引数がnilの他の呼び出し箇所でも堅牢になる
+
+## References
+
+- [Issue #13: Gyaim on/off時の挙動](https://github.com/tanabe1478/SwiftyGyaim/issues/13)
+- [google/mozc - deactivateServer実装](https://github.com/google/mozc)
+- [ensan-hcl/macOS_IMKitSample_2021](https://github.com/ensan-hcl/macOS_IMKitSample_2021)


### PR DESCRIPTION
## Summary

- IME切替（deactivateServer）時に未確定テキストが破棄される問題を修正（Closes #13）
- `fix(client:)` に `self.client()` フォールバックを追加し、`fixAsKana()` と同じパターンでクライアントを解決
- Mozc/Google日本語入力等と同じ標準動作に統一

## Changes

| ファイル | 変更 |
|---------|------|
| `GyaimController.swift` | `deactivateServer` で `fix(client: sender)` を渡す + `fix(client:)` のクライアント解決に `self.client()` フォールバック追加 |
| `CLAUDE.md` | Key Constraintsにdeactivation時の挙動を追記 |
| `docs/adr/012-commit-preedit-on-deactivation.md` | ADR追加 |

## Root Cause

`deactivateServer(_:)` が `fix()` を引数なしで呼んでいたため、`fix(client:)` 内の `sender as? IMKTextInput` キャストが常に失敗し、`resetState()` でテキストが破棄されていた。

## Test plan

- [x] 既存ユニットテスト151件全パス
- [x] 手動テスト: テキストエディタで入力中にIME切替 → テキストが確定されることを確認
- [x] ログ確認: `IME deactivated: committing preedit` + `Fixed:` が出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)