### PR TITLE
fix: IME切替時の確定で学習辞書に登録しない

### DIFF
--- a/GyaimSwift/Sources/Gyaim/GyaimController.swift
+++ b/GyaimSwift/Sources/Gyaim/GyaimController.swift
@@ -128,7 +128,7 @@ class GyaimController: IMKInputController {
     override func deactivateServer(_ sender: Any!) {
         Log.input.info("IME deactivated: committing preedit (converting=\(converting), candidates=\(candidates.count))")
         hideWindow()
-        fix(client: sender)
+        fix(client: sender, skipStudy: true)
         ws?.finish()
     }
 
@@ -736,7 +736,7 @@ class GyaimController: IMKInputController {
 
     // MARK: - Fix (commit selection)
 
-    private func fix(client sender: Any? = nil) {
+    private func fix(client sender: Any? = nil, skipStudy: Bool = false) {
         guard nthCand < candidates.count else {
             resetState()
             return
@@ -762,19 +762,25 @@ class GyaimController: IMKInputController {
             client.insertText(word, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
         }
 
-        // Register or study logic
-        let isExternalCandidate = (word == clipboardCandidate || word == selectedCandidate)
-        if isExternalCandidate {
-            // External candidate (clipboard/selected text) → register to user dict
-            ws?.register(word: word, reading: inputPat)
-            Log.input.info("Registered to user dict: \"\(word)\" (reading: \"\(inputPat)\")")
-        } else if let reading = candidate.reading {
-            if reading != "ds" {
-                ws?.study(word: word, reading: reading)
-            }
+        // Register or study logic (skip when deactivating — user didn't intentionally select)
+        if skipStudy {
+            Log.input.info("Study skipped (deactivation): \"\(word)\" (reading: \"\(reading)\")")
         } else {
-            if inputPat != "ds" {
-                ws?.study(word: word, reading: inputPat)
+            let isExternalCandidate = (word == clipboardCandidate || word == selectedCandidate)
+            if isExternalCandidate {
+                // External candidate (clipboard/selected text) → register to user dict
+                ws?.register(word: word, reading: inputPat)
+                Log.input.info("Registered to user dict: \"\(word)\" (reading: \"\(inputPat)\")")
+            } else if let reading = candidate.reading {
+                if reading != "ds" {
+                    ws?.study(word: word, reading: reading)
+                    Log.input.info("Studied: \"\(word)\" (reading: \"\(reading)\")")
+                }
+            } else {
+                if inputPat != "ds" {
+                    ws?.study(word: word, reading: inputPat)
+                    Log.input.info("Studied: \"\(word)\" (reading: \"\(inputPat)\")")
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- IME切替（deactivateServer）による自動確定時に学習辞書への登録をスキップする
- `fix()` に `skipStudy` パラメータを追加、deactivation時は `true` で呼び出し
- 辞書登録/学習/スキップの各パスにログ出力を追加（`Studied:` / `Study skipped:` / `Registered:`）

## Context

PR #17 でIME切替時に未確定テキストを確定するよう修正したが、確定時に学習辞書（studydict.txt）にも登録されてしまい、次回入力時に意図しない候補が上位に表示される問題があった。deactivationはユーザーが意図的に候補を選んだわけではないため、学習すべきではない。

## Test plan

- [x] 既存ユニットテスト全パス
- [x] 手動テスト: IME切替で確定 → ログに `Study skipped (deactivation)` が出力される
- [x] 手動テスト: 通常確定（Enter） → ログに `Studied:` が出力される
- [x] 手動テスト: 未入力状態でIME切替 → エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)