### PR TITLE
docs: 3階層コンテキスト基盤の導入 (ADR-013)

### DIFF
--- a/.claude/hooks/pr-spec-reminder.sh
+++ b/.claude/hooks/pr-spec-reminder.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Post-PR-creation hook: Remind about spec and bug-memory updates
+# Fires on: gh pr create
+
+# Read stdin (hook payload)
+INPUT=$(cat)
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$REPO_ROOT" ]; then
+  echo "$INPUT"
+  exit 0
+fi
+
+# Get all files changed since branching from master
+CHANGED=$(git diff --name-only master...HEAD 2>/dev/null | grep '\.swift$')
+if [ -z "$CHANGED" ]; then
+  echo "$INPUT"
+  exit 0
+fi
+
+SPECS_DIR="$REPO_ROOT/docs/specs"
+SPECS_CHANGED=$(git diff --name-only master...HEAD 2>/dev/null | grep '^docs/specs/')
+BUG_MEMORY_CHANGED=$(echo "$SPECS_CHANGED" | grep 'bug-memory.md')
+
+echo "" >&2
+echo "[PR Spec Check] Swift files changed in this PR:" >&2
+for f in $CHANGED; do
+  echo "  - $f" >&2
+done
+
+if [ -z "$SPECS_CHANGED" ]; then
+  echo "" >&2
+  echo "[PR Spec Check] WARNING: No specs were updated in this PR." >&2
+  echo "[PR Spec Check] Review docs/specs/ for any specs that need updating." >&2
+else
+  echo "" >&2
+  echo "[PR Spec Check] Specs updated: $SPECS_CHANGED" >&2
+fi
+
+if [ -z "$BUG_MEMORY_CHANGED" ]; then
+  # Check if this looks like a bug fix branch
+  BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+  if echo "$BRANCH" | grep -qi "fix"; then
+    echo "" >&2
+    echo "[PR Spec Check] This appears to be a bug fix branch." >&2
+    echo "[PR Spec Check] Consider adding an entry to docs/specs/bug-memory.md" >&2
+  fi
+fi
+
+echo "$INPUT"
+exit 0

--- a/.claude/hooks/spec-freshness-check.sh
+++ b/.claude/hooks/spec-freshness-check.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Pre-commit hook: Check if changed .swift files have specs that may need updating
+# Fires on: git commit
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$REPO_ROOT" ]; then
+  exit 0
+fi
+
+SPECS_DIR="$REPO_ROOT/docs/specs"
+if [ ! -d "$SPECS_DIR" ]; then
+  exit 0
+fi
+
+# Get staged .swift files
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null | grep '\.swift$')
+if [ -z "$STAGED" ]; then
+  exit 0
+fi
+
+# Map files to specs via Trigger lines
+SPECS_TO_CHECK=""
+for spec in "$SPECS_DIR"/*.md; do
+  [ -f "$spec" ] || continue
+  triggers=$(head -5 "$spec" | grep '^> Trigger:' | sed 's/> Trigger: //')
+  if [ -z "$triggers" ]; then
+    continue
+  fi
+  for staged_file in $STAGED; do
+    basename=$(basename "$staged_file")
+    if echo "$triggers" | grep -q "$basename"; then
+      spec_name=$(basename "$spec")
+      spec_date=$(head -5 "$spec" | grep '^> Last updated:' | sed 's/> Last updated: //')
+      SPECS_TO_CHECK="$SPECS_TO_CHECK\n  - $spec_name (last updated: $spec_date) ← triggered by $basename"
+    fi
+  done
+done
+
+if [ -n "$SPECS_TO_CHECK" ]; then
+  echo "[Spec Check] The following specs may need updating:" >&2
+  echo -e "$SPECS_TO_CHECK" >&2
+  echo "" >&2
+  echo "[Spec Check] If you made behavioral changes, update the relevant spec in docs/specs/" >&2
+  echo "[Spec Check] If you fixed a bug, add an entry to docs/specs/bug-memory.md" >&2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash(git commit*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tanabe.nobuyuki/Documents/repositories/SwiftyGyaim/.claude/hooks/spec-freshness-check.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "tool == \"Bash\" && tool_input.command matches \"gh pr create\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/tanabe.nobuyuki/Documents/repositories/SwiftyGyaim/.claude/hooks/pr-spec-reminder.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,10 @@ nbproject
 .dat*.*
 LOG.md
 PLAN.md
-.claude/
+# .claude - ignore all except hooks and shared settings
+.claude/*
+!.claude/hooks/
+!.claude/settings.json
 docs/gyaim-learning-roadmap.md
 docs/gyaim-learning-curriculum.md
 docs/gyaim-week1-tasklist.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,3 +189,38 @@ Gyaim設定 > 候補セクションで以下を切り替え可能（UserDefaults
 Gyaim設定 > Google変換セクションで以下を設定可能:
 - **トリガー文字**: 入力末尾に付けてGoogle変換を発動（デフォルト`` ` ``）。UserDefaultsキー `googleTransliterateTrigger`
 - **ショートカット**: 変換中に押すとGoogle変換を発動（設定画面で追加/削除）。KeyBindingsで永続化
+
+## Context Infrastructure (3-Tier Docs)
+
+arXiv:2602.20478 に基づく3階層ドキュメントシステム（ADR-013）。
+
+### Tier 1: 常時読込 → このファイル (CLAUDE.md)
+
+### Tier 2: 領域特化仕様書 → `docs/specs/`
+
+**ルール（必須）**:
+1. `.swift` ファイルを編集する前に、下表のTrigger列に該当するspecをReadすること
+2. バグ修正後は `docs/specs/bug-memory.md` にエントリを追記すること
+3. 動作仕様を変更した場合は、対応するspecを同じコミットで更新すること
+
+| Spec | Trigger（編集対象） | 内容 |
+|------|-------------------|------|
+| [input-flow.md](docs/specs/input-flow.md) | GyaimController.swift | キー入力→変換→確定フロー、routeEvent設計 |
+| [dictionary-system.md](docs/specs/dictionary-system.md) | WordSearch.swift, ConnectionDict.swift | 3階層辞書、学習、ホットリロード |
+| [candidate-window.md](docs/specs/candidate-window.md) | CandidateWindow.swift, PreferencesWindow.swift | 候補表示モード、NSPanel制約 |
+| [google-transliterate.md](docs/specs/google-transliterate.md) | GoogleTransliterate.swift | Google API連携、非同期処理、stale guard |
+| [imk-constraints.md](docs/specs/imk-constraints.md) | GyaimController.swift, AppDelegate.swift, main.swift | InputMethodKit固有の制約と回避策 |
+| [bug-memory.md](docs/specs/bug-memory.md) | 全ファイル（デバッグ時） | 過去のバグパターンと修正方法 |
+
+### Tier 3: オンデマンド検索 → `docs/adr/`
+
+- `docs/adr/` — 設計判断の経緯（000-013）
+
+### 自動チェック（hooks）
+
+- **Pre-commit**: 変更された.swiftファイルに対応するspecの鮮度をチェック、bug-memory更新リマインド
+- **PR作成後**: spec更新漏れの最終確認、bugfixブランチならbug-memory追記リマインド
+
+### メンテナンス
+
+週次（目安30分）: git logから変更を確認し、影響するspecを更新。新規バグはbug-memory.mdに追記。

--- a/docs/adr/013-three-tier-context-infrastructure.md
+++ b/docs/adr/013-three-tier-context-infrastructure.md
@@ -1,0 +1,80 @@
+# ADR-013: 3階層コンテキスト基盤の導入
+
+## Status
+
+Accepted
+
+## Decision
+
+論文 "Codified Context: Infrastructure for AI Agents in a Complex Codebase" (arXiv:2602.20478) の3階層ドキュメントシステムをSwiftyGyaimの開発フローに導入する。
+
+## Context
+
+AIコーディングにおいて、セッション間で記憶が共有されないため、プロジェクトの規約や過去のミスを繰り返す問題がある。論文では、ドキュメントを3階層に整理し、AIが状況に応じて参照する仕組みで、10万行規模でも高品質なコード生成を実現した。
+
+SwiftyGyaimは3,950行と小規模だが、InputMethodKitの特殊な制約やIME固有のパターンが多く、セッションごとにコンテキストを失うコストが大きい。
+
+## Consideration
+
+### 現状の資産と論文の3階層のマッピング
+
+| 論文の階層 | 定義 | SwiftyGyaim現状 | 対応 |
+|-----------|------|----------------|------|
+| **Tier 1 (常時読込)** | 基本ルール、やってはいけないミス | CLAUDE.md | 既にある。強化する |
+| **Tier 2 (領域トリガー)** | 特化エージェント仕様書 | なし | 新設: `docs/specs/` |
+| **Tier 3 (オンデマンド検索)** | 詳細仕様書 | docs/codemaps/, docs/adr/ | 既にある。索引を整備 |
+
+### 論文で特に重要な知見
+
+1. **Specの鮮度が命** — 古い情報は誤ったコードを生む。週1-2時間のメンテナンスが必要
+2. **バグメモリ** — 過去のバグ修正記録をAIが引き出せることで、人間が特定できない問題を発見
+3. **人間の役割シフト** — コードを書くことから「AIが迷わない知識基盤」の設計・管理へ
+
+## Consequences
+
+### ディレクトリ構成
+
+```
+CLAUDE.md                          ← Tier 1: 常時読込
+docs/
+├── specs/                         ← Tier 2: 領域特化仕様書（新設）
+│   ├── input-flow.md              # キー入力→変換→確定フロー
+│   ├── dictionary-system.md       # 3階層辞書（search/study/register）
+│   ├── candidate-window.md        # 候補表示（list/classic, positioning）
+│   ├── google-transliterate.md    # Google API連携（async, stale guard）
+│   ├── imk-constraints.md         # InputMethodKit制約集
+│   └── bug-memory.md              # 過去のバグと修正パターン
+└── adr/                           ← Tier 3: 設計判断の記録
+    └── *.md
+```
+
+### 各階層の役割
+
+**Tier 1: CLAUDE.md（常時読込）**
+- PR作成ルール、ビルドコマンド、テスト実行方法
+- Key Constraints（IMEの重要な制約）
+- **新規追加**: よくあるミスのリスト（bug-memoryからの昇格）
+- **新規追加**: specs/への索引（どの領域を触るときにどのspecを読むか）
+
+**Tier 2: docs/specs/（領域トリガー）**
+- 特定ファイルを編集する際に参照すべき仕様書
+- トリガー条件をファイル冒頭に明記（例: `Trigger: GyaimController.swift, WordSearch.swift`）
+- 過去のバグパターンと回避策を含む
+
+**Tier 3: docs/codemaps/, docs/adr/（オンデマンド）**
+- コードマップ: ファイル間の依存関係、データフロー
+- ADR: 設計判断の経緯と理由
+- 必要なときだけ検索して参照
+
+### メンテナンスフロー
+
+週次（目安30分、小規模プロジェクトのため）:
+1. 直近のgit logからspec更新が必要な変更を特定
+2. 影響するspecを更新
+3. 新たに発見したバグパターンをbug-memory.mdに追記
+4. 頻出パターンはCLAUDE.mdに昇格
+
+## References
+
+- [arXiv:2602.20478 - Codified Context: Infrastructure for AI Agents in a Complex Codebase](https://arxiv.org/pdf/2602.20478)
+- [Algomatic AILab による解説](https://x.com/Algomatic_AILab/status/2032028482520432762)

--- a/docs/specs/bug-memory.md
+++ b/docs/specs/bug-memory.md
@@ -1,0 +1,51 @@
+# Spec: バグメモリ
+
+> Trigger: 全ファイル（デバッグ時に参照）
+> Last updated: 2026-03-17
+
+## 概要
+
+過去に発生したバグとその修正パターンを記録する。AIがデバッグ時にこのファイルを参照することで、同じ問題の再発を防ぐ。
+
+## バグ記録
+
+### BUG-001: deactivation時に未確定テキストが消える
+
+- **Issue**: #13
+- **発見日**: 2026-03-17
+- **影響**: IME切替時にユーザーの入力が消失
+- **原因**: `deactivateServer(_:)` が `fix()` を引数なしで呼び、`sender as? IMKTextInput` が常に失敗
+- **修正**: `fix(client: sender)` でsenderを渡す + `self.client()` フォールバック追加
+- **教訓**: IMKTextInputのクライアント取得は必ず `self.client()` フォールバックを入れること
+- **関連ADR**: ADR-012
+
+### BUG-002: deactivation確定でstudyDictに意図しない登録
+
+- **Issue**: #13 (follow-up)
+- **発見日**: 2026-03-17
+- **影響**: IME切替時の自動確定でローマ字がそのまま学習辞書に登録され、次回入力時に不要な候補が出現
+- **原因**: `fix()` が常に `ws?.study()` を呼んでいた
+- **修正**: `fix(client:skipStudy:)` パラメータ追加、deactivation時は `skipStudy: true`
+- **教訓**: ユーザーが意図的に選択していない確定では学習しないこと
+- **関連PR**: #18
+
+## パターン集
+
+### パターン: IMKTextInputクライアント取得
+
+**常にフォールバックを使う**:
+```swift
+let resolvedClient = (sender as? IMKTextInput) ?? (self.client() as? IMKTextInput)
+guard let client = resolvedClient else { ... }
+```
+
+`sender` が nil や予期しない型の場合がある（特にライフサイクルメソッド）。
+
+### パターン: ライフサイクルメソッドでの副作用
+
+deactivateServer等のライフサイクルメソッドでは:
+1. UIを先にクリーンアップ（hideWindow）
+2. テキスト処理（fix）
+3. リソース解放（ws?.finish）
+
+の順で実行。テキスト処理でクライアントが取得できない場合でもUIクリーンアップは完了させる。

--- a/docs/specs/candidate-window.md
+++ b/docs/specs/candidate-window.md
@@ -1,0 +1,34 @@
+# Spec: 候補ウィンドウ
+
+> Trigger: CandidateWindow.swift, PreferencesWindow.swift
+> Last updated: 2026-03-17
+
+## 概要
+
+NSPanelベースの非アクティブウィンドウ。フォーカスを奪わない（`.nonactivatingPanel`）。
+
+## 表示モード
+
+| モード | 最大候補数 | レイアウト | 選択表示 |
+|--------|-----------|----------|---------|
+| list | 9 | 縦リスト、番号1-9 | ハイライト行 |
+| classic | 11 | 横並び、candwin.png背景 | 下線 |
+
+UserDefaultsキー: `candidateDisplayMode` (Int, 0=list, 1=classic, デフォルト1)
+
+## Classic背景の描画
+
+`ClassicBackgroundView`: candwin.pngを9スライス描画（上部/中央/下部をストレッチ）。候補数に応じて幅を可変。
+
+## 位置計算
+
+`CandidateWindowPositioner`: クライアントから取得した`lineRect`（カーソル位置）を基準に表示位置を計算。画面境界でクランプ。
+
+## モード切替の実装
+
+NSLayoutConstraintのactivation/deactivationで切り替え。list用のNSStackViewとclassic用のClassicBackgroundViewを両方保持し、表示時に切り替える。
+
+## 既知の制約
+
+- IMEはLSBackgroundOnlyのため、`NSApp.unhide(nil)` は使えない。`orderFront(nil)` のみ（ADR-005）
+- NSPanelの`.nonactivatingPanel`は必須。通常のNSWindowだとフォーカスを奪う（ADR-006）

--- a/docs/specs/dictionary-system.md
+++ b/docs/specs/dictionary-system.md
@@ -1,0 +1,52 @@
+# Spec: 辞書システム
+
+> Trigger: WordSearch.swift, ConnectionDict.swift
+> Last updated: 2026-03-17
+
+## 概要
+
+3階層の辞書を優先度順に検索し、候補を返す。
+
+## 辞書の優先度
+
+| 優先度 | 辞書 | ファイル | 最大件数 | 特徴 |
+|--------|------|---------|---------|------|
+| 1 (最高) | Study | ~/.gyaim/studydict.txt | 1000 (MRU) | 使用頻度で自動昇降 |
+| 2 | Local | ~/.gyaim/localdict.txt | 無制限 | ユーザー手動登録 |
+| 3 | Connection | Resources/dict.txt | ~40K | 形態素解析辞書 |
+
+## ファイル形式
+
+Study/Local: タブ区切り `reading\tword`
+Connection: タブ区切り `romaji\tsurface\tinConnection\toutConnection`
+
+## 検索モード
+
+| mode | 名称 | トリガー | 動作 |
+|------|------|---------|------|
+| 0 | 前方一致 | 文字入力ごと | inputPatの前方一致で候補を返す（インクリメンタル） |
+| 1 | 完全一致 | Space（候補なし時） | inputPatの完全一致 + ひらがな/カタカナ自動追加 |
+| 2 | Google | トリガー文字/ショートカット | GoogleTransliterate APIの結果 |
+
+## 学習の仕組み
+
+### study()
+- `studyDict` の先頭に `[reading, word]` を挿入（MRU）
+- 1000件を超えると末尾を切り捨て
+- 同じ単語がstudyDictに既存かつconnectionDictに未登録の場合、localDictに昇格（`register()`）
+
+### register()
+- `localDict` に `[reading, word]` を追加
+- ファイルに即座に書き出し
+
+### deactivation時はstudy()をスキップ
+IME切替による自動確定ではユーザーが意図的に候補を選んでいないため、`fix(skipStudy: true)` で学習を抑制する。
+
+## ホットリロード
+
+`search()` 呼び出し時に `localdict.txt` のmtimeをチェックし、変更があれば再読み込み。DictEditorWindowでの編集を即座に反映するため。
+
+## 既知の制約
+
+- search()のデフォルトlimitは10件。表示側の上限（list:9, classic:11）との不整合あり
+- studyDictは起動時に全件メモリ読み込み

--- a/docs/specs/google-transliterate.md
+++ b/docs/specs/google-transliterate.md
@@ -1,0 +1,49 @@
+# Spec: Google Transliterate連携
+
+> Trigger: GoogleTransliterate.swift
+> Last updated: 2026-03-17
+
+## 概要
+
+内蔵辞書で変換できない語のフォールバック。Google Input Tools APIにひらがなを送信し、漢字候補を取得。
+
+## API
+
+- **Endpoint**: `https://inputtools.google.com/request`
+- **Method**: GET
+- **Parameters**: text (ひらがな), itc=ja-t-i0-handwrit
+- **Timeout**: 3秒
+
+## トリガー方式
+
+1. **サフィックス文字**: inputPatの末尾にトリガー文字（デフォルト`` ` ``）を付ける
+   - UserDefaultsキー: `googleTransliterateTrigger`
+2. **キーボードショートカット**: 変換中に押すとGoogle変換を発動
+   - KeyBindingsで永続化
+
+## 非同期処理フロー
+
+```
+triggerGoogleTransliterate()
+  → pendingGoogleQuery = inputPat   ← stale guard用
+  → URLSession.dataTask (async)
+      → callback:
+          guard pendingGoogleQuery == originalQuery  ← staleチェック
+          → combineSegments() → 直積結合 (max 20件)
+          → filterCandidates() → ひらがな重複除去
+          → DispatchQueue.main で候補更新
+```
+
+## Stale Guard
+
+APIレスポンスが返る前にユーザーが入力を変更した場合、古い結果を破棄する。`pendingGoogleQuery` に発行時のクエリを保存し、コールバックで一致を確認。
+
+## セグメント結合
+
+APIは入力を複数セグメントに分割して返す（例: 「ますいとしゆき」→ [「増井」「俊之」]）。`combineSegments()` で直積を取り、最大20件に制限。
+
+## 既知の制約
+
+- Google APIは外部依存のため、オフラインでは機能しない
+- タイムアウト3秒は固定値
+- API仕様変更のリスクあり（非公開API）

--- a/docs/specs/imk-constraints.md
+++ b/docs/specs/imk-constraints.md
@@ -1,0 +1,51 @@
+# Spec: InputMethodKit制約集
+
+> Trigger: GyaimController.swift, AppDelegate.swift, main.swift, CandidateWindow.swift
+> Last updated: 2026-03-17
+
+## 概要
+
+macOS InputMethodKitフレームワーク固有の制約と回避策。IME開発で繰り返し遭遇するハマりポイントを集約。
+
+## 制約一覧
+
+### 1. LSBackgroundOnly
+
+IMEアプリは `LSBackgroundOnly = true` で動作する。
+
+- `NSApp.unhide(nil)` を呼ぶとフォーカスを失う → **使用禁止**
+- ウィンドウ表示は `orderFront(nil)` のみ（ADR-005）
+- 設定画面やエディタを開くときは `NSApp.setActivationPolicy(.accessory)` を一時的に設定し、閉じたら `.prohibited` に戻す
+
+### 2. NSPanel (非アクティブウィンドウ)
+
+候補ウィンドウはNSPanelの `.nonactivatingPanel` スタイルが必須（ADR-006）。通常のNSWindowだとIMEがフォーカスを奪い、入力先アプリからフォーカスが外れる。
+
+### 3. Ctrl+key のターミナルでの動作
+
+ターミナルアプリ（Terminal.app, iTerm2等）はCtrl+keyをIMEより先にインターセプトする。IME側のCtrl+keyショートカットは届かない場合がある。回避策: single-key shortcuts（`;`、`q`）を併用。
+
+### 4. deactivateServerのsender
+
+`deactivateServer(_:)` の `sender` 引数はクライアント（IMKTextInput）だが、nil や非IMKTextInputの場合がある。**必ず `self.client()` フォールバックを使うこと**。
+
+```swift
+// 正しいパターン（fixAsKana, fix共通）
+let resolvedClient = (sender as? IMKTextInput) ?? (self.client() as? IMKTextInput)
+```
+
+### 5. メニューバーアイコン
+
+20x20 PDF形式が必須。Retina対応のためPNGではなくPDFを使用。
+
+### 6. IMKTextInputのselectedRange
+
+`client.selectedRange()` はアプリによって信頼性が異なる。一部アプリではNSNotFoundを返す。
+
+### 7. setMarkedText / insertText の順序
+
+`setMarkedText` で下線付きテキストを表示し、`insertText` で確定する。`insertText` を呼ぶとmarked textは自動的にクリアされる。
+
+### 8. IMKServer のシングルトン
+
+`main.swift` で作成する `IMKServer` はアプリのライフタイム中1つだけ。GyaimControllerのインスタンスは入力ソースの切り替えごとに再生成される可能性がある。staticプロパティ（`lastConsumedCC`等）はこのため必要。

--- a/docs/specs/input-flow.md
+++ b/docs/specs/input-flow.md
@@ -1,0 +1,59 @@
+# Spec: キー入力フロー
+
+> Trigger: GyaimController.swift
+> Last updated: 2026-03-17
+
+## 概要
+
+GyaimControllerはIMKInputControllerのサブクラスで、全キー入力の処理を担う。
+
+## 入力状態
+
+| 変数 | 型 | 意味 |
+|------|---|------|
+| `inputPat` | String | 現在のローマ字入力 |
+| `candidates` | [SearchCandidate] | 現在の候補リスト |
+| `nthCand` | Int | 選択中の候補インデックス |
+| `searchMode` | Int | 0=前方一致, 1=完全一致, 2=Google結果 |
+| `converting` | Bool (computed) | `!inputPat.isEmpty` |
+
+## イベント処理の流れ
+
+```
+handle(_:client:) → routeEvent() → HandleResult
+                         ↓
+            handleResultに応じた副作用実行
+            ├─ 文字入力 → searchAndShowCands()
+            ├─ Space → 候補サイクル or searchMode遷移
+            ├─ Enter → fix() で確定
+            ├─ ESC → resetState()
+            ├─ BS → inputPat末尾削除
+            └─ F6/F7/shortcut → fixAsKana()
+```
+
+## routeEvent() の設計意図
+
+`handle(_:client:)` から副作用のない純粋な分岐ロジックを抽出し、`routeEvent()` static methodとして独立させた（ADR-009）。これによりMockIMKTextInputを使わずにユニットテスト可能。
+
+## 確定パス
+
+| パス | メソッド | 学習 | 用途 |
+|------|---------|------|------|
+| Enter/数字キー | `fix(client:)` | あり | 通常確定 |
+| F6/`;` | `fixAsKana(hiragana: true)` | あり | ひらがな確定 |
+| F7/`q` | `fixAsKana(hiragana: false)` | あり | カタカナ確定 |
+| IME切替 | `fix(client:sender, skipStudy: true)` | **なし** | deactivation確定 |
+
+## IMEライフサイクル
+
+```
+activateServer(_:) → 辞書start, クリップボード取得, showWindow
+deactivateServer(_:) → hideWindow, fix(skipStudy: true), 辞書finish
+```
+
+**重要**: deactivationではsenderをfix()に渡すこと。渡さないとクライアント取得に失敗しテキストが破棄される（Issue #13で修正済み）。
+
+## 既知の制約
+
+- `handle(_:client:)` のclientはIMKTextInputだが、ターミナルアプリではCtrl+keyを横取りされる
+- `routeEvent()` はstaticだがGyaimControllerのインスタンス状態に依存する引数を受け取る


### PR DESCRIPTION
## Summary

- arXiv:2602.20478 "Codified Context" に基づく3階層ドキュメントシステムを導入
- Tier 2として `docs/specs/` に領域特化仕様書6件を新設
- Pre-commitとPR作成時のhookでspec鮮度チェックを自動化
- codemapsは役割重複のため不採用（specsとADRで代替）

## 3階層構成

| 階層 | 場所 | トリガー |
|------|------|---------|
| Tier 1 | CLAUDE.md | 常時読込 |
| Tier 2 | docs/specs/ (6件) | .swiftファイル編集前にRead |
| Tier 3 | docs/adr/ (13件) | オンデマンド検索 |

## Hooks

| タイミング | 動作 |
|-----------|------|
| Pre-commit | 変更.swiftに対応するspecの鮮度チェック + bug-memory更新リマインド |
| PR作成後 | spec更新漏れ確認、bugfixブランチならbug-memory追記リマインド |

## 追加ファイル

- `docs/specs/input-flow.md` — キー入力→確定フロー
- `docs/specs/dictionary-system.md` — 3階層辞書
- `docs/specs/candidate-window.md` — 候補表示
- `docs/specs/google-transliterate.md` — Google API連携
- `docs/specs/imk-constraints.md` — InputMethodKit制約集
- `docs/specs/bug-memory.md` — 過去のバグパターン
- `docs/adr/013-three-tier-context-infrastructure.md` — ADR
- `.claude/hooks/` — 自動チェックスクリプト2件
- `.claude/settings.json` — hooks登録

## Test plan

- [x] hookスクリプトが実行可能（chmod +x済み）
- [ ] 次回コミット時にspec-freshness-checkが発火することを確認
- [ ] 次回PR作成時にpr-spec-reminderが発火することを確認

## References

- [arXiv:2602.20478](https://arxiv.org/pdf/2602.20478)

🤖 Generated with [Claude Code](https://claude.com/claude-code)