### PR TITLE
完全一致優先オプションのヒント文言を改善

### DIFF
--- a/GyaimSwift/Sources/Gyaim/PreferencesWindow.swift
+++ b/GyaimSwift/Sources/Gyaim/PreferencesWindow.swift
@@ -188,7 +188,7 @@ class PreferencesWindow: NSWindow {
         contentBox.addSubview(erToggle)
         exactReadingMatchToggle = erToggle
 
-        let erHint = makeLabel("ONにすると「設定」が「設定画面」より先に表示されるようになります")
+        let erHint = makeLabel("入力と読みが完全に一致する候補を、前方一致の候補より上に表示します")
         erHint.font = NSFont.systemFont(ofSize: 11)
         erHint.textColor = .secondaryLabelColor
         y -= 18
@@ -483,7 +483,7 @@ class PreferencesWindow: NSWindow {
         contentBox.addSubview(erToggle)
         exactReadingMatchToggle = erToggle
 
-        let erHint = makeLabel("ONにすると「設定」が「設定画面」より先に表示されるようになります")
+        let erHint = makeLabel("入力と読みが完全に一致する候補を、前方一致の候補より上に表示します")
         erHint.font = NSFont.systemFont(ofSize: 11)
         erHint.textColor = .secondaryLabelColor
         y -= 18


### PR DESCRIPTION
## Summary
- 設定画面の「完全一致の読みを優先する」チェックボックスのヒント文言を改善
- 旧: `ONにすると「設定」が「設定画面」より先に表示されるようになります` — 具体例ベースで機能の意味が伝わりにくい
- 新: `入力と読みが完全に一致する候補を、前方一致の候補より上に表示します` — 機能の一般的な動作を説明

## Test plan
- [x] ビルド成功（BUILD SUCCEEDED）
- [x] 全210テストパス（TEST SUCCEEDED）

🤖 Generated with [Claude Code](https://claude.com/claude-code)