### PR TITLE
fix: study()ごとに学習辞書をファイル保存して学習消失を防ぐ

### DIFF
--- a/GyaimSwift/Sources/Gyaim/AppDelegate.swift
+++ b/GyaimSwift/Sources/Gyaim/AppDelegate.swift
@@ -15,6 +15,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         Log.config.info("Gyaim terminating")
+        // セーフティネット: study() が毎回保存するので通常は冗長だが、
+        // deactivateServer を経由しない終了ケースに備えて明示的に保存する
+        GyaimController.saveStudyDictIfNeeded()
         FileLogger.shared.flush()
         clipboardTimer?.invalidate()
     }

--- a/GyaimSwift/Sources/Gyaim/GyaimController.swift
+++ b/GyaimSwift/Sources/Gyaim/GyaimController.swift
@@ -132,6 +132,13 @@ class GyaimController: IMKInputController {
         ws?.finish()
     }
 
+    /// AppDelegate.applicationWillTerminate から呼ばれるセーフティネット。
+    /// study() 自体が毎回ファイル保存するので通常は冗長だが、deactivateServer が
+    /// 呼ばれずに終了するケース（プロセスkill等）への備えとして残す。
+    static func saveStudyDictIfNeeded() {
+        shared?.ws?.finish()
+    }
+
     private func resetState() {
         inputPat = ""
         candidates = []

--- a/GyaimSwift/Sources/Gyaim/WordSearch.swift
+++ b/GyaimSwift/Sources/Gyaim/WordSearch.swift
@@ -286,6 +286,10 @@ class WordSearch {
         }
 
         evict()
+        // study() 呼び出しごとにファイル保存する。これをしないと、IMEプロセスが
+        // deactivateServer を経由せずに終了したとき（killall, クラッシュ等）に
+        // メモリ上の学習エントリがすべて失われる。
+        Self.saveStudyDict(dictFile: studyDictFile, dict: studyDict)
     }
 
     private static let maxStudyEntries = 10_000

--- a/GyaimSwift/Tests/GyaimTests/WordSearchTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/WordSearchTests.swift
@@ -144,6 +144,33 @@ final class WordSearchTests: XCTestCase {
         XCTAssertEqual(tokyo?.frequency, 2)
     }
 
+    /// BUG: study() はメモリ上のstudyDictに追加するのみで、finish() を呼ぶまでファイルに保存されない。
+    /// IMEプロセスがdeactivateServerを経由せず終了すると、学習が失われる（例: Google変換で確定した「明示的」が消える）。
+    /// 修正後は study() 呼び出し後、finish() を呼ばずともファイルに永続化されること。
+    func testStudyPersistsToFileWithoutFinish() throws {
+        try XCTSkipIf(ws == nil)
+        ws.study(word: "明示的", reading: "meijiteki")
+        // 意図的に finish() を呼ばない
+        let entries = WordSearch.loadStudyDict(
+            dictFile: tempDir.appendingPathComponent("studydict.txt").path)
+        XCTAssertTrue(entries.map(\.word).contains("明示的"),
+                      "study() should persist to disk immediately, without requiring finish()")
+    }
+
+    /// frequency インクリメントパスも同様に永続化されること
+    func testStudyFrequencyIncrementPersistsWithoutFinish() throws {
+        try XCTSkipIf(ws == nil)
+        ws.study(word: "明示的", reading: "meijiteki")
+        ws.study(word: "明示的", reading: "meijiteki")
+        // 意図的に finish() を呼ばない
+        let entries = WordSearch.loadStudyDict(
+            dictFile: tempDir.appendingPathComponent("studydict.txt").path)
+        let entry = entries.first { $0.word == "明示的" }
+        XCTAssertNotNil(entry, "Entry should exist on disk after study()")
+        XCTAssertEqual(entry?.frequency, 2,
+                       "Frequency should be 2 after two study() calls, even without finish()")
+    }
+
     func testEvictMRU() throws {
         try XCTSkipIf(ws == nil)
         EvictionMode.setCurrent(.mru)

--- a/docs/specs/bug-memory.md
+++ b/docs/specs/bug-memory.md
@@ -1,7 +1,7 @@
 # Spec: バグメモリ
 
 > Trigger: 全ファイル（デバッグ時に参照）
-> Last updated: 2026-03-17
+> Last updated: 2026-04-15
 
 ## 概要
 
@@ -28,6 +28,21 @@
 - **修正**: `fix(client:skipStudy:)` パラメータ追加、deactivation時は `skipStudy: true`
 - **教訓**: ユーザーが意図的に選択していない確定では学習しないこと
 - **関連PR**: #18
+
+### BUG-003: study辞書がファイルに保存されず学習が失われる
+
+- **発見日**: 2026-04-15
+- **症状**: Google変換で「明示的」を何度確定しても候補に残らない。ログには `Studied: "明示的" (reading: "meijiteki")` が記録されているが、studydict.txt には該当エントリが存在しない
+- **影響**: IMEプロセスが `deactivateServer` を経由せず終了した場合（killall, クラッシュ, OSによる強制終了等）、そのセッション中にstudyされた語がすべて失われる
+- **原因**: `WordSearch.study()` はメモリ上の `studyDict` 配列を更新するのみで、ファイル保存（`saveStudyDict`）を呼んでいなかった。保存は `finish()`（deactivateServer経由）か `deleteFromStudy()` のみで行われていた
+- **修正**:
+  - `study()` の `evict()` 直後に `Self.saveStudyDict(...)` を追加（メイン修正）
+  - `AppDelegate.applicationWillTerminate` で `GyaimController.saveStudyDictIfNeeded()` を呼ぶセーフティネット追加
+- **検証**: `testStudyPersistsToFileWithoutFinish`, `testStudyFrequencyIncrementPersistsWithoutFinish` の2テストを追加
+- **教訓**:
+  - メモリ上の変更は必ずファイル保存とペアで行うこと。片方だけ実装すると、ライフサイクルメソッドが呼ばれないケースでデータが失われる
+  - `deleteFromStudy` が保存しているのに `study` が保存していない非対称性は設計上の赤信号
+  - 「ログには残っているがファイルに存在しない」現象は、メモリと永続化の乖離を示すシグナル
 
 ## パターン集
 

--- a/docs/specs/dictionary-system.md
+++ b/docs/specs/dictionary-system.md
@@ -1,7 +1,7 @@
 # Spec: 辞書システム
 
 > Trigger: WordSearch.swift, ConnectionDict.swift
-> Last updated: 2026-04-08
+> Last updated: 2026-04-15
 
 ## 概要
 
@@ -48,6 +48,7 @@ Connection: タブ区切り `romaji\tsurface\tinConnection\toutConnection`
 - 新規エントリ: `StudyEntry(lastAccessTime: now, frequency: 1)` を先頭に挿入
 - 上限超過時に淘汰方式に応じたevictionを実行
 - 同じ単語がstudyDictに既存かつconnectionDictに未登録の場合、localDictに昇格（`register()`）
+- **ファイル保存**: evict後に `saveStudyDict` を呼び即座に永続化する。これをしないと、IMEプロセスが `deactivateServer` を経由せず終了したとき（killall, クラッシュ等）に学習データがすべて失われる。保存は原子的（tempfile + rename）なのでクラッシュ耐性がある。
 
 ### 淘汰方式（EvictionMode）
 


### PR DESCRIPTION
## Summary

- Google変換で「明示的」を何度確定しても候補に残らない問題を修正
- `WordSearch.study()` がメモリ上の `studyDict` を更新するのみでファイル保存していなかったため、IMEプロセスが `deactivateServer` を経由せず終了すると学習がすべて失われていた
- `study()` 呼び出しごとに `saveStudyDict` を呼ぶよう修正、`applicationWillTerminate` でもセーフティネットとして保存

## Problem

ユーザー報告: 「明示的」をGoogle変換で繰り返し確定しても候補から消える。

ログ調査の結果:

\`\`\`
[2026-04-15 14:12:22] [input] [info] Fixed: \"明示的\" (reading: \"meijiteki\", ...)
[2026-04-15 14:12:22] [input] [info] Studied: \"明示的\" (reading: \"meijiteki\")
[2026-04-15 14:19:03] [input] [info] Studied: \"明示的\" (reading: \"meijiteki\")
\`\`\`

ログでは2回 studied されているのに、`studydict.txt` には「明示的」も「meijiteki」も存在しない（1,132件で上限10,000件の11%しか埋まっていないため eviction ではない）。

## Root Cause

`WordSearch.study()` はメモリ上の `studyDict` 配列に追加するのみで、`saveStudyDict()` を呼んでいなかった。保存は以下でのみ発生:

- \`finish()\` — `deactivateServer` 経由でのみ呼ばれる（IME切替時）
- \`deleteFromStudy()\` — 候補削除時のみ

IMEプロセスが `killall`、クラッシュ、OSによる強制終了で `deactivateServer` を経由せず終了すると、メモリ上の学習エントリがすべて失われる。`deleteFromStudy` が保存しているのに `study` が保存していない非対称性は設計上の見落とし。

## Fix

1. **\`WordSearch.study()\`**: `evict()` の直後に `Self.saveStudyDict(...)` を追加（メイン修正）
2. **\`GyaimController\`**: \`AppDelegate\` から呼べる \`saveStudyDictIfNeeded()\` static メソッドを追加
3. **\`AppDelegate.applicationWillTerminate\`**: セーフティネットとして保存呼び出し追加

## Tests

新規テスト2件を追加（RED→GREEN確認済）:

- \`testStudyPersistsToFileWithoutFinish\`: \`study()\` 後、\`finish()\` を呼ばずにファイルにエントリが存在することを検証
- \`testStudyFrequencyIncrementPersistsWithoutFinish\`: 2回目の \`study()\` で frequency が 2 として永続化されていることを検証

全212テスト（既存210 + 新規2）グリーン。

## Performance

- production studydict は約1,132件で100KB程度。atomic write（tempfile+rename）でも sub-ms。
- eviction系テスト（10,002件study）は1件ごとに書き込みが増えるが、テスト全体200秒で許容範囲内。

## Spec Updates

- \`docs/specs/dictionary-system.md\`: \`study()\` が即座にファイル保存することを明記
- \`docs/specs/bug-memory.md\`: BUG-003 として記録

## Test plan

- [x] ユニットテスト全212件グリーン
- [x] 新規2テストが修正前にFAIL、修正後にPASSすることを確認
- [ ] 手動E2E: ビルド&インストール後、Google変換で「明示的」を確定 → \`killall SwiftyGyaim\` → 再起動で studydict.txt に残っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)