### PR TITLE
fix: CIでCopyTextTestsが落ちる問題を修正 + PR時のテスト自動化

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        working-directory: GyaimSwift
+        run: xcodegen generate
+
+      - name: Run tests
+        working-directory: GyaimSwift
+        run: |
+          xcodebuild -project Gyaim.xcodeproj \
+            -scheme GyaimTests \
+            -derivedDataPath .build \
+            test

--- a/GyaimSwift/Tests/GyaimTests/CopyTextTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/CopyTextTests.swift
@@ -4,6 +4,16 @@ import XCTest
 
 final class CopyTextTests: XCTestCase {
 
+    /// CI環境では ~/.gyaim/ が存在せず CopyText.set() がファイル書き込みに失敗する。
+    /// ローカル開発環境では既にあるので影響なし。createDirectory は冪等。
+    override func setUp() {
+        super.setUp()
+        try? FileManager.default.createDirectory(
+            atPath: Config.gyaimDir,
+            withIntermediateDirectories: true
+        )
+    }
+
     // MARK: - CopyText file I/O
 
     func testGetReturnsSetContent() {


### PR DESCRIPTION
## Summary

- v1.5リリース時にCIで CopyTextTests の3件が失敗していた問題を修正
- PRとmaster pushで全テストを自動実行するワークフローを追加

## Problem

v1.5タグpushで走った release workflow の \`Run tests\` ステップが失敗:

\`\`\`
CopyTextTests.testGetReturnsSetContent()
CopyTextTests.testNilInputIgnored()
CopyTextTests.testTimestampNotUpdatedOnSameContent()
\`\`\`

### Root Cause

\`CopyText\` は \`~/.gyaim/copytext\` に読み書きするが、CI環境（GitHub Actions macos-latest）では \`~/.gyaim/\` ディレクトリが存在しない。

- \`set()\` の \`text.write(toFile: file, ...)\` が失敗（ディレクトリなし）
- \`get()\` の \`String(contentsOfFile: file)\` も失敗し空文字列を返す
- \`curtext != text\` の判定で常に true になり、同じ内容の再 set() でも timestamp が更新されてしまう

ローカル環境では既に \`~/.gyaim/\` が存在するため気付かれず、v1.4 リリース時のCI失敗も同じ原因だったと推測される。

## Fix

### 1. CopyTextTests に setUp を追加

\`\`\`swift
override func setUp() {
    super.setUp()
    try? FileManager.default.createDirectory(
        atPath: Config.gyaimDir,
        withIntermediateDirectories: true
    )
}
\`\`\`

- \`createDirectory(withIntermediateDirectories: true)\` は冪等なのでローカル環境に影響なし
- CI環境では必要なディレクトリを確実に作成

### 2. .github/workflows/test.yml を追加

PRとmaster pushで全テストを自動実行するワークフロー。

- 今後のCI破壊をマージ前に検知できる
- 独立したワークフローなので release.yml のビルド/DMG/リリース作成には影響しない

## Verification

- ローカルで全212テストグリーン（CopyTextTests 7件含む）
- このPR自体が新しい test.yml ワークフローをトリガーするため、マージ前にCI動作を確認可能

## Test plan

- [x] ローカルで CopyTextTests 単独実行グリーン
- [x] ローカルで全212テストグリーン
- [ ] PRの test.yml ワークフローがグリーン（CIで同じ修正が効くことを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)