### PR TITLE
fix: 完全一致reading優先を辞書をまたいだ4バケット順序で適用 (BUG-004)

### DIFF
--- a/GyaimSwift/Sources/Gyaim/WordSearch.swift
+++ b/GyaimSwift/Sources/Gyaim/WordSearch.swift
@@ -142,9 +142,17 @@ class WordSearch {
 
         let exactPriority = searchMode == 0 && Self.isExactReadingMatchPriority
 
-        // Search study dict
         if exactPriority {
-            // Pass 1: exact reading matches first
+            // 4-bucket cross-dict ordering (BUG-004):
+            //   1. studyDict exact   2. localDict exact
+            //   3. studyDict prefix  4. localDict prefix
+            // connectionDict は最後 (元の位置を維持) — 静的辞書の単漢字が
+            // 学習済み prefix 候補を押し流さないようにするため。
+            // 同表記 word の dedup は先着勝ちなので、user-owned (study/local) が
+            // 必ず先に列挙されることで .source = .connection で上書きされず、
+            // Shift+X による削除（GyaimController.deleteCurrentCandidate）が機能する。
+
+            // Bucket 1: studyDict exact (reading == q)
             for entry in studyDict {
                 if entry.reading == q, !candfound.contains(entry.word) {
                     candidates.append(SearchCandidate(word: entry.word, reading: entry.reading, source: .study))
@@ -152,7 +160,20 @@ class WordSearch {
                     if limit > 0, candidates.count >= limit { break }
                 }
             }
-            // Pass 2: prefix-only matches
+            // Bucket 2: localDict exact (yomi == q)
+            if limit == 0 || candidates.count < limit {
+                for entry in localDict {
+                    guard entry.count >= 2 else { continue }
+                    let yomi = entry[0]
+                    let word = entry[1]
+                    if yomi == q, !candfound.contains(word) {
+                        candidates.append(SearchCandidate(word: word, reading: yomi, source: .local))
+                        candfound.insert(word)
+                        if limit > 0, candidates.count >= limit { break }
+                    }
+                }
+            }
+            // Bucket 3: studyDict prefix
             if limit == 0 || candidates.count < limit {
                 for entry in studyDict {
                     let range = NSRange(entry.reading.startIndex..., in: entry.reading)
@@ -164,7 +185,23 @@ class WordSearch {
                     }
                 }
             }
+            // Bucket 4: localDict prefix
+            if limit == 0 || candidates.count < limit {
+                for entry in localDict {
+                    guard entry.count >= 2 else { continue }
+                    let yomi = entry[0]
+                    let word = entry[1]
+                    let range = NSRange(yomi.startIndex..., in: yomi)
+                    if regex.firstMatch(in: yomi, range: range) != nil,
+                       !candfound.contains(word) {
+                        candidates.append(SearchCandidate(word: word, reading: yomi, source: .local))
+                        candfound.insert(word)
+                        if limit > 0, candidates.count >= limit { break }
+                    }
+                }
+            }
         } else {
+            // OFF: single-pass per dict (現状挙動を維持)
             for entry in studyDict {
                 let range = NSRange(entry.reading.startIndex..., in: entry.reading)
                 if regex.firstMatch(in: entry.reading, range: range) != nil {
@@ -175,38 +212,7 @@ class WordSearch {
                     }
                 }
             }
-        }
-
-        // Search local dict
-        if limit == 0 || candidates.count < limit {
-            if exactPriority {
-                // Pass 1: exact reading matches first
-                for entry in localDict {
-                    guard entry.count >= 2 else { continue }
-                    let yomi = entry[0]
-                    let word = entry[1]
-                    if yomi == q, !candfound.contains(word) {
-                        candidates.append(SearchCandidate(word: word, reading: yomi, source: .local))
-                        candfound.insert(word)
-                        if limit > 0, candidates.count >= limit { break }
-                    }
-                }
-                // Pass 2: prefix-only matches
-                if limit == 0 || candidates.count < limit {
-                    for entry in localDict {
-                        guard entry.count >= 2 else { continue }
-                        let yomi = entry[0]
-                        let word = entry[1]
-                        let range = NSRange(yomi.startIndex..., in: yomi)
-                        if regex.firstMatch(in: yomi, range: range) != nil,
-                           !candfound.contains(word) {
-                            candidates.append(SearchCandidate(word: word, reading: yomi, source: .local))
-                            candfound.insert(word)
-                            if limit > 0, candidates.count >= limit { break }
-                        }
-                    }
-                }
-            } else {
+            if limit == 0 || candidates.count < limit {
                 for entry in localDict {
                     guard entry.count >= 2 else { continue }
                     let yomi = entry[0]

--- a/GyaimSwift/Tests/GyaimTests/WordSearchTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/WordSearchTests.swift
@@ -538,6 +538,87 @@ final class WordSearchTests: XCTestCase {
             "Default OFF: MRU order should be preserved (設定画面 before 設定)")
     }
 
+    // MARK: - Cross-Dict Exact Priority (BUG-004)
+
+    /// localDict の exact match が studyDict の prefix match より先に出ること。
+    /// 報告: ken → 件 が 検索/検討/検証/権限/けんげん/懸念 の後ろに埋もれていた。
+    func testLocalExactBeatsStudyPrefix() throws {
+        try XCTSkipIf(ws == nil)
+        WordSearch.setExactReadingMatchPriority(true)
+        // studyDict に prefix match を作る (kensaku は "ken" で前方一致)
+        ws.study(word: "検索", reading: "kensaku")
+        ws.study(word: "検討", reading: "kentou")
+        // localDict に exact match を作る (reading == "ken")
+        ws.register(word: "件", reading: "ken")
+
+        let results = ws.search(query: "ken", searchMode: 0)
+        let words = results.map(\.word)
+        guard let idxKen = words.firstIndex(of: "件"),
+              let idxKensaku = words.firstIndex(of: "検索") else {
+            XCTFail("Expected both 件 and 検索 in results: \(words)")
+            return
+        }
+        XCTAssertLessThan(idxKen, idxKensaku,
+            "localDict exact '件' should come before studyDict prefix '検索', got: \(words)")
+    }
+
+    /// studyDict の exact match は localDict の exact match より先に出ること（既存階層維持）。
+    func testStudyExactBeatsLocalExact() throws {
+        try XCTSkipIf(ws == nil)
+        WordSearch.setExactReadingMatchPriority(true)
+        // localDict にも studyDict にも reading == "abc" の語をそれぞれ別単語で登録
+        ws.register(word: "ローカル語", reading: "abc")
+        ws.study(word: "学習語", reading: "abc")
+
+        let results = ws.search(query: "abc", searchMode: 0)
+        let words = results.map(\.word)
+        guard let idxStudy = words.firstIndex(of: "学習語"),
+              let idxLocal = words.firstIndex(of: "ローカル語") else {
+            XCTFail("Expected both words in results: \(words)")
+            return
+        }
+        XCTAssertLessThan(idxStudy, idxLocal,
+            "studyDict exact should come before localDict exact, got: \(words)")
+    }
+
+    /// connection-only な単語は studyDict prefix より後に残ること（6バケット案を採用していないことの保証）。
+    /// "man" は connectionDict に複数 exact match (万, 萬等) が存在する。studyDict に prefix match の "manga"
+    /// を作ったとき、connection の単漢字が前に飛び出さないこと。
+    func testConnectionExactDoesNotJumpAheadOfStudyPrefix() throws {
+        try XCTSkipIf(ws == nil)
+        WordSearch.setExactReadingMatchPriority(true)
+        // studyDict に prefix match を作る
+        ws.study(word: "漫画", reading: "manga")
+
+        let results = ws.search(query: "man", searchMode: 0)
+        let words = results.map(\.word)
+        guard let idxManga = words.firstIndex(of: "漫画") else {
+            XCTFail("Expected 漫画 in results: \(words)")
+            return
+        }
+        // connection 由来の "万" が 漫画 より後にあるべき (前にあれば 6 バケット化 = 退行)
+        if let idxMan = words.firstIndex(of: "万") {
+            XCTAssertLessThan(idxManga, idxMan,
+                "studyDict prefix '漫画' should come before connectionDict exact '万', got: \(words)")
+        }
+    }
+
+    /// localDict と connectionDict 両方に存在する語は localDict 由来 (.local source) として返ること。
+    /// これにより Shift+X による候補削除（GyaimController.deleteCurrentCandidate）が機能する。
+    func testLocalExactSourcePreservedOverConnection() throws {
+        try XCTSkipIf(ws == nil)
+        WordSearch.setExactReadingMatchPriority(true)
+        // 件 は connectionDict (Resources/dict.txt) にも存在する。
+        // ユーザーが手動 register した場合、結果の source は .local であるべき。
+        ws.register(word: "件", reading: "ken")
+
+        let results = ws.search(query: "ken", searchMode: 0)
+        let kenCandidate = results.first { $0.word == "件" }
+        XCTAssertNotNil(kenCandidate, "Expected 件 in results")
+        XCTAssertEqual(kenCandidate?.source, .local,
+            "件 should be marked as .local (not .connection) so it can be deleted with Shift+X")
+    }
+
     func testExactMatchSearchModeUnchanged() throws {
         try XCTSkipIf(ws == nil)
         ws.study(word: "設定", reading: "settei")

--- a/docs/adr/016-exact-reading-match-priority.md
+++ b/docs/adr/016-exact-reading-match-priority.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Superseded by ADR-017 (辞書をまたいだ4バケット順序に拡張)
 
 ## Decision
 

--- a/docs/adr/017-cross-dict-exact-priority.md
+++ b/docs/adr/017-cross-dict-exact-priority.md
@@ -1,0 +1,101 @@
+# ADR-017: 完全一致reading優先を辞書をまたいで適用
+
+## Status
+
+Accepted (supersedes ADR-016 — extends its scope from per-dict to cross-dict)
+
+## Decision
+
+ADR-016 で導入した完全一致reading優先を、**辞書をまたいだ4バケット順序**で適用する:
+
+```
+1. studyDict exact   (reading == q)
+2. localDict exact   (yomi == q)
+3. studyDict prefix  (regex prefix match)
+4. localDict prefix
+5. connectionDict    (現状の挙動を維持、最後)
+```
+
+`exactReadingMatchPriority` が ON のときのみ適用。OFF時の挙動は完全に維持。
+
+## Context
+
+ADR-016 では `exactReadingMatchPriority = ON` のとき、各辞書（study, local）内で2パス（exact → prefix）に分けて優先表示していた。しかし**辞書をまたいだ exact > prefix の整理は行っていなかった**。
+
+### 報告された症状（BUG-004）
+
+ユーザーが `ken` で `件` を毎回確定しても、studyDict に学習済みの `kensaku → 検索`, `kentou → 検討`, `kensyou → 検証`, `kengen → 権限` 等の **prefix match** が先に並び、localDict の **exact match** である `件` (reading=ken) は **7番目** に埋もれた。`exactReadingMatchPriority = ON` でも改善せず、ユーザーは "完全一致優先" の契約が満たされていないと感じた。
+
+### 原因
+
+`WordSearch.search()` の探索順:
+
+```
+ADR-016 の挙動:
+  studyDict exact → studyDict prefix → localDict exact → localDict prefix → connection
+                                       ↑ '件' がここまで来ない
+```
+
+**studyDict prefix が localDict exact より先**に列挙されるため、localDict の exact 候補が studyDict の prefix 群に押し下げられていた。
+
+## Consideration
+
+Codex CLI (gpt-5.1) と2往復のセカンドオピニオンを実施。検討した代替案:
+
+### Option A: 4バケット (採用)
+
+```
+study-exact → local-exact → study-prefix → local-prefix → connection(all)
+```
+
+- メリット: 報告バグを最小差分で修正。予測変換の体験を維持
+- 既存ユーザー手動登録 (`localDict`) または学習済み (`studyDict`) の exact のみ前置
+- connection 由来の単漢字（`県, 権, 圏, 拳, 券...`）は元の位置に留まる
+
+### Option B: 6バケット (却下)
+
+```
+study-exact → local-exact → connection-exact → study-prefix → local-prefix → connection-prefix
+```
+
+却下理由:
+- `ken` の connectionDict exact は16件 (`県, 権, 圏, 拳, 券, 軒, 健, 剣, 件, 堅, 兼, 検, 建, 研, 犬, 賢`) もあり、1ページ目（list mode 9枠）が単漢字で埋まる
+- 学習済みの `検索/検討/検証` が1ページ目から消え、予測変換の体験が著しく劣化
+- dedup 先着勝ちにより `connection exact` が `local exact` より前に出ると `source = .connection` となり、Shift+X 候補削除（GyaimController.deleteCurrentCandidate）が機能しなくなる
+
+### Option C: rank tuple stable sort (将来検討)
+
+`(isExact, sourceTier, frequency, recency, ...)` の tuple で全候補を stable sort。
+- メリット: 最も柔軟、Mozc 風の汎用ランキング
+- デメリット: 現状の `study` 永続化問題（BUG-003）解決後、緊急度なし。over-engineering
+- 将来 default ON 化や予測精度向上を狙うときの本命
+
+## Consequences
+
+- 有効時: localDict exact が studyDict prefix より先に表示される。報告ケース `ken → 件` 解決
+- 無効時: 完全に従来通り（OFF分岐は touch せず）
+- studyDict / localDict は **走査回数2回** になる（exact pass + prefix pass）が、≤10,000件の線形スキャンなので実用影響なし
+- connectionDict は単一バケット維持のため、connection-only な短い exact は元の位置を維持
+- dedup 先着勝ちにより、user-owned dict (study/local) の `source` が保持され、候補削除機能と整合
+
+## Test Coverage
+
+| Test | 検証内容 |
+|------|---------|
+| `testLocalExactBeatsStudyPrefix` | 報告バグの直接的再現と修正検証 |
+| `testStudyExactBeatsLocalExact` | 階層 (study > local) の維持 |
+| `testConnectionExactDoesNotJumpAheadOfStudyPrefix` | 6バケット採用していないこと（regression防止） |
+| `testLocalExactSourcePreservedOverConnection` | source = .local 維持で削除機能と整合 |
+
+既存 ADR-016 の4テスト（`testExactReadingMatchPrioritizedOverPrefix`, `testExactMatchOrderPreservedWithinGroup`, `testPrefixMatchOrderPreservedWithinGroup`, `testLocalDictExactReadingMatchPrioritized`, `testDefaultDisabledPreservesExistingBehavior`）も全てpass。
+
+## Future Work
+
+- rank tuple stable sort への移行（Option C）— default ON 化や Mozc 風予測精度向上を狙うとき
+- connection exact の救済（手動 promote ボタン or 短縮reading 自動提案）— 今回のスコープ外
+
+## References
+
+- ADR-016: 完全一致reading優先（基礎機能）
+- BUG-004: cross-dict exact priority (docs/specs/bug-memory.md)
+- Codex CLI 2往復相談 (2026-04-15)

--- a/docs/specs/bug-memory.md
+++ b/docs/specs/bug-memory.md
@@ -1,7 +1,7 @@
 # Spec: バグメモリ
 
 > Trigger: 全ファイル（デバッグ時に参照）
-> Last updated: 2026-04-15
+> Last updated: 2026-04-15 (BUG-004追加)
 
 ## 概要
 
@@ -43,6 +43,25 @@
   - メモリ上の変更は必ずファイル保存とペアで行うこと。片方だけ実装すると、ライフサイクルメソッドが呼ばれないケースでデータが失われる
   - `deleteFromStudy` が保存しているのに `study` が保存していない非対称性は設計上の赤信号
   - 「ログには残っているがファイルに存在しない」現象は、メモリと永続化の乖離を示すシグナル
+
+### BUG-004: 完全一致reading優先が辞書をまたがず localDict exact が studyDict prefix に埋もれる
+
+- **発見日**: 2026-04-15
+- **症状**: ユーザーが `ken` で `件` を毎回確定しても、候補リストで `件` が常に7番目に出る。`exactReadingMatchPriority = ON` でも改善せず
+- **影響**: 短い読みの語が長い読みの学習済み prefix 候補に押し流される。ADR-016 の "完全一致優先" の契約が事実上守られていない
+- **原因**: `WordSearch.search()` が `studyDict (exact + prefix) → localDict (exact + prefix) → connection` の順で探索しており、**studyDict prefix が localDict exact より先に列挙**される。各辞書内では2-passだが、**辞書をまたいだ exact > prefix の整理がされていなかった**
+- **修正**:
+  - `WordSearch.search()` の `exactPriority == true` 分岐を **4バケット順序** に変更: `study-exact → local-exact → study-prefix → local-prefix → connection` (ADR-017)
+  - connection は単一バケット維持（6バケット案を採用すると、`ken` の単漢字16件が予測候補を押し流すため却下）
+- **検証**:
+  - `testLocalExactBeatsStudyPrefix`（直接的再現と修正検証）
+  - `testStudyExactBeatsLocalExact`（階層維持）
+  - `testConnectionExactDoesNotJumpAheadOfStudyPrefix`（regression防止: 6バケット採用していないこと）
+  - `testLocalExactSourcePreservedOverConnection`（dedup先着勝ちで .local source 維持）
+- **教訓**:
+  - 「機能をONにしたが contract を満たさない」は ON/OFF 設定とは別の設計バグ。設定の有無ではなく**仕様の一貫性**を疑うべき
+  - dedup の先着勝ちは `source` フィールドの整合性に直結する。priorityを変えるときは候補削除機能との連動を必ず確認
+  - 辞書をまたいだランキング設計は connectionDict の static 単漢字を考慮しないと UX が劣化する。"all exact first" は素朴すぎる
 
 ## パターン集
 

--- a/docs/specs/dictionary-system.md
+++ b/docs/specs/dictionary-system.md
@@ -1,7 +1,7 @@
 # Spec: 辞書システム
 
 > Trigger: WordSearch.swift, ConnectionDict.swift
-> Last updated: 2026-04-15
+> Last updated: 2026-04-15 (ADR-017対応)
 
 ## 概要
 
@@ -102,15 +102,25 @@ SearchCandidateに`source`フィールドを追加し、各候補の出自を追
 - `.study` / `.local` → 削除可能
 - `.connection` / `.external` / `.synthetic` → 削除不可
 
-## 完全一致reading優先（ADR-016）
+## 完全一致reading優先（ADR-016 → ADR-017）
 
 設定画面のトグルで有効/無効を切り替え可能。UserDefaultsキー `exactReadingMatchPriority`（Bool、デフォルトfalse）。
 
-有効時、前方一致検索（searchMode == 0）でstudy dict / local dictを2パスで走査:
-1. Pass 1: `entry.reading == query`（完全一致）
-2. Pass 2: prefix matchのみ（完全一致は既にcandfoundでスキップ）
+有効時、前方一致検索（searchMode == 0）で**辞書をまたいだ4バケット順序**で走査（ADR-017）:
 
-各パス内のMRU順序は維持。connection dictは対象外（静的辞書のため）。
+```
+1. studyDict exact   (entry.reading == query)
+2. localDict exact   (yomi == query)
+3. studyDict prefix  (regex prefix match)
+4. localDict prefix
+5. connectionDict    (single pass, 現状の挙動)
+```
+
+各バケット内のMRU順序は維持。connection dictは単一バケット維持（静的辞書の単漢字exactで予測候補が押し流されるのを避けるため）。
+
+dedup は `word` 単位の先着勝ちなので、user-owned dict (study/local) が先に列挙されることで `source = .connection` で上書きされず、Shift+X による候補削除（`GyaimController.deleteCurrentCandidate`）が機能する。
+
+OFF時は単一パス（study → local → connection）で従来どおり MRU 順。
 
 ## 既知の制約
 


### PR DESCRIPTION
## Summary

- ユーザー報告 \`ken → 件\` が候補で常に7番目に埋もれる問題を修正
- 完全一致reading優先を**辞書をまたいだ4バケット順序**に拡張 (ADR-017)
- Codex CLI と2往復の設計レビューを経て、6バケット案を却下し4バケット案を採用

## Problem (BUG-004)

ユーザーが \`ken\` で \`件\` を毎回確定しても、候補リストで \`件\` が常に **7番目** に埋もれる。\`exactReadingMatchPriority = ON\` でも改善せず、ADR-016 の "完全一致優先" の契約が事実上守られていない状態だった。

### Root cause

\`WordSearch.search()\` の探索順:
\`\`\`
ADR-016 の挙動:
  studyDict (exact + prefix) → localDict (exact + prefix) → connection
                ↑ ここで 検索/検討/検証/権限... が列挙される
                                       ↑ ここまで来ない: 件 (localDict exact)
\`\`\`

各辞書内では2-passだが、**辞書をまたいだ exact > prefix の整理がされていなかった**。studyDict prefix が localDict exact より先に出るため、\`件\` のような短い読みの語が学習済みの長い読みの語に押し流されていた。

## Fix

\`exactPriority == true\` 分岐を **4バケット順序** に変更:

\`\`\`
1. studyDict exact   (entry.reading == query)
2. localDict exact   (yomi == query)
3. studyDict prefix  (regex prefix match)
4. localDict prefix
5. connectionDict    (single pass、現状の挙動を維持)
\`\`\`

OFF時の挙動は完全に維持。default OFF 維持。

## Design Decision: なぜ6バケットでなく4バケット？

Codex CLI (gpt-5.1) と2往復の設計レビューを実施。6バケット案 (\`connection-exact\` を3番目に置く) は以下の理由で却下:

- \`ken\` の connectionDict exact は **16件** (\`県, 権, 圏, 拳, 券, 軒, 健, 剣, 件, 堅, 兼, 検, 建, 研, 犬, 賢\`) もあり、1ページ目（list mode 9枠）が単漢字で埋まる
- 学習済みの \`検索/検討/検証\` が1ページ目から消え、予測変換の体験が著しく劣化
- dedup 先着勝ちにより \`connection exact\` が \`local exact\` より前に出ると \`source = .connection\` となり、Shift+X 候補削除が機能しなくなる

詳細は ADR-017 参照。

## Tests

新規4件追加:
- \`testLocalExactBeatsStudyPrefix\` — 報告バグの直接的再現と修正検証 (RED→GREEN確認済)
- \`testStudyExactBeatsLocalExact\` — 階層 (study > local) の維持
- \`testConnectionExactDoesNotJumpAheadOfStudyPrefix\` — 6バケット採用していないこと（regression防止）
- \`testLocalExactSourcePreservedOverConnection\` — dedup先着勝ちで \`.local source\` 維持、削除機能と整合

ローカルで全テスト (216件、新規4件含む) **グリーン**。

## Spec Updates

CLAUDE.md Tier 2 ルールに従い同コミットで更新:
- \`docs/adr/017-cross-dict-exact-priority.md\` 新規作成
- \`docs/adr/016-exact-reading-match-priority.md\` Status を \`Superseded by ADR-017\` に
- \`docs/specs/dictionary-system.md\` 完全一致reading優先セクションを4バケット説明に更新
- \`docs/specs/bug-memory.md\` BUG-004 として記録

## Test plan

- [x] 全216テスト ローカルでグリーン
- [x] 新規4テストが修正前にFAIL、修正後にPASS
- [x] OFF時の既存テスト (\`testDefaultDisabledPreservesExistingBehavior\`) 引き続きパス
- [ ] CI \`Test\` ワークフローがグリーン (PR時に自動実行)
- [ ] 手動E2E: ビルド&インストール後、\`ken\` 入力で \`件\` が1番目に出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)