### PR TITLE
docs: ADR-017とexactReadingMatchPriorityトグルをspecに反映

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,8 @@ docs/adr/
 ├── 013-three-tier-context-infrastructure.md
 ├── 014-score-based-study-dict-eviction.md
 ├── 015-delete-candidate-from-dictionary.md
-└── 016-exact-reading-match-priority.md
+├── 016-exact-reading-match-priority.md (Superseded by ADR-017)
+└── 017-cross-dict-exact-priority.md
 ```
 
 ## Logging & Monitoring

--- a/docs/specs/candidate-window.md
+++ b/docs/specs/candidate-window.md
@@ -1,7 +1,7 @@
 # Spec: 候補ウィンドウ
 
 > Trigger: CandidateWindow.swift, PreferencesWindow.swift
-> Last updated: 2026-03-21 (平仮名学習トグル追加)
+> Last updated: 2026-04-15 (完全一致reading優先トグル追加 ADR-016/017)
 
 ## 概要
 
@@ -51,6 +51,10 @@ NSLayoutConstraintのactivation/deactivationで切り替え。list用のNSStackV
 - **平仮名学習**: チェックボックス「平仮名の確定を学習する」（デフォルトON）
 - UserDefaultsキー: `studyHiraganaEnabled` (Bool, デフォルトtrue)
 - `toggleStudyHiragana(_:)` アクションで即座にUserDefaultsに保存
+- **完全一致reading優先**: チェックボックス「完全一致の読みを優先する」（デフォルトOFF、ADR-016/017）
+- UserDefaultsキー: `exactReadingMatchPriority` (Bool, デフォルトfalse)
+- `toggleExactReadingMatchPriority(_:)` アクションで即座にUserDefaultsに保存
+- ON時は前方一致検索 (searchMode==0) で4バケット順序 (study-exact → local-exact → study-prefix → local-prefix → connection) で候補を並べる（詳細は dictionary-system.md）
 
 ## 既知の制約
 


### PR DESCRIPTION
## Summary

ドキュメント監査で発見した2件の漏れを修正。

## 監査で見つかった漏れ

1. **CLAUDE.md の ADR リスト** が ADR-016 で止まっており、ADR-017 が記載されていなかった
2. **candidate-window.md** の PreferencesWindow セクションに完全一致reading優先トグル (UserDefaultsキー \`exactReadingMatchPriority\`) の説明が欠けていた（PR #33 でラベル改善、PR #36 で4バケット化されたが spec 未追従）

## Fix

- \`CLAUDE.md\`: ADRリストに \`017-cross-dict-exact-priority.md\` を追加、016 を \`Superseded by ADR-017\` 注記
- \`docs/specs/candidate-window.md\`: 学習辞書セクションに完全一致reading優先チェックボックスの説明を追加、\`Last updated\` を 2026-04-15 に更新

## Test plan

- [x] CLAUDE.md, candidate-window.md がリポジトリ実態と一致
- [x] コードのみ変更なし、テスト不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)