### PR TITLE
fix: studyDictをstatic化して複数インスタンス間の学習データ上書きを防止 (BUG-005)

### DIFF
--- a/GyaimSwift/Sources/Gyaim/WordSearch.swift
+++ b/GyaimSwift/Sources/Gyaim/WordSearch.swift
@@ -61,22 +61,38 @@ class WordSearch {
 
     private let connectionDict: ConnectionDict
     private let localDictFile: String
-    private let studyDictFile: String
     private var localDict: [[String]]   // [[yomi, word], ...]
-    private var studyDict: [StudyEntry]
     private var localDictTime: Date
     private var searchMode: Int = 0
 
+    // MARK: - Shared Study Dict (process-wide singleton)
+    // IMKInputControllerはクライアントアプリごとにインスタンスを生成するため、
+    // studyDictをインスタンス変数にすると、あるインスタンスのsaveStudyDictが
+    // 別インスタンスの学習データを上書きして消す（BUG-005）。
+    // プロセス全体で1つのstudyDictを共有することでこの問題を解決する。
+    private(set) static var studyDict: [StudyEntry] = []
+    private(set) static var studyDictFile: String = ""
+
+    /// テスト用: static studyDict をリセットして次の init() で再読み込みさせる。
+    static func resetStudyDict() {
+        studyDict = []
+        studyDictFile = ""
+    }
+
     init(connectionDictFile: String, localDictFile: String, studyDictFile: String) {
         self.localDictFile = localDictFile
-        self.studyDictFile = studyDictFile
         self.connectionDict = PerfLog.measure("ConnectionDict load", logger: Log.dict) {
             ConnectionDict(dictFile: connectionDictFile)
         }
         self.localDict = Self.loadDict(dictFile: localDictFile)
         self.localDictTime = Self.fileModTime(localDictFile)
-        self.studyDict = Self.loadStudyDict(dictFile: studyDictFile)
-        Log.dict.info("WordSearch initialized: local=\(localDict.count), study=\(studyDict.count) entries")
+        // studyDict はプロセス内で1回だけロードする。
+        // ファイルパスが変わった場合（テスト等）は再ロード。
+        if Self.studyDictFile != studyDictFile {
+            Self.studyDictFile = studyDictFile
+            Self.studyDict = Self.loadStudyDict(dictFile: studyDictFile)
+        }
+        Log.dict.info("WordSearch initialized: local=\(localDict.count), study=\(Self.studyDict.count) entries")
     }
 
     /// Main search method.
@@ -153,7 +169,7 @@ class WordSearch {
             // Shift+X による削除（GyaimController.deleteCurrentCandidate）が機能する。
 
             // Bucket 1: studyDict exact (reading == q)
-            for entry in studyDict {
+            for entry in Self.studyDict {
                 if entry.reading == q, !candfound.contains(entry.word) {
                     candidates.append(SearchCandidate(word: entry.word, reading: entry.reading, source: .study))
                     candfound.insert(entry.word)
@@ -175,7 +191,7 @@ class WordSearch {
             }
             // Bucket 3: studyDict prefix
             if limit == 0 || candidates.count < limit {
-                for entry in studyDict {
+                for entry in Self.studyDict {
                     let range = NSRange(entry.reading.startIndex..., in: entry.reading)
                     if regex.firstMatch(in: entry.reading, range: range) != nil,
                        !candfound.contains(entry.word) {
@@ -202,7 +218,7 @@ class WordSearch {
             }
         } else {
             // OFF: single-pass per dict (現状挙動を維持)
-            for entry in studyDict {
+            for entry in Self.studyDict {
                 let range = NSRange(entry.reading.startIndex..., in: entry.reading)
                 if regex.firstMatch(in: entry.reading, range: range) != nil {
                     if !candfound.contains(entry.word) {
@@ -274,20 +290,20 @@ class WordSearch {
             }
             if !registered {
                 // If in study dict but not connection dict, promote to local dict
-                if studyDict.contains(where: { $0.reading == reading && $0.word == word }) {
+                if Self.studyDict.contains(where: { $0.reading == reading && $0.word == word }) {
                     register(word: word, reading: reading)
                 }
             }
         }
 
         let now = Date().timeIntervalSince1970
-        if let idx = studyDict.firstIndex(where: { $0.reading == reading && $0.word == word }) {
-            var entry = studyDict.remove(at: idx)
+        if let idx = Self.studyDict.firstIndex(where: { $0.reading == reading && $0.word == word }) {
+            var entry = Self.studyDict.remove(at: idx)
             entry.lastAccessTime = now
             entry.frequency += 1
-            studyDict.insert(entry, at: 0)
+            Self.studyDict.insert(entry, at: 0)
         } else {
-            studyDict.insert(StudyEntry(reading: reading, word: word,
+            Self.studyDict.insert(StudyEntry(reading: reading, word: word,
                                          lastAccessTime: now, frequency: 1), at: 0)
         }
 
@@ -295,7 +311,7 @@ class WordSearch {
         // study() 呼び出しごとにファイル保存する。これをしないと、IMEプロセスが
         // deactivateServer を経由せずに終了したとき（killall, クラッシュ等）に
         // メモリ上の学習エントリがすべて失われる。
-        Self.saveStudyDict(dictFile: studyDictFile, dict: studyDict)
+        Self.saveStudyDict(dictFile: Self.studyDictFile, dict: Self.studyDict)
     }
 
     private static let maxStudyEntries = 10_000
@@ -303,15 +319,15 @@ class WordSearch {
     private func evict() {
         switch EvictionMode.current {
         case .mru, .none:
-            if studyDict.count > Self.maxStudyEntries {
-                studyDict = Array(studyDict.prefix(Self.maxStudyEntries))
+            if Self.studyDict.count > Self.maxStudyEntries {
+                Self.studyDict = Array(Self.studyDict.prefix(Self.maxStudyEntries))
             }
         case .scoreBased:
-            if studyDict.count > Self.maxStudyEntries {
-                let protectedCount = min(100, studyDict.count)
-                let range = protectedCount..<studyDict.count
-                if let minIdx = range.min(by: { studyDict[$0].score() < studyDict[$1].score() }) {
-                    studyDict.remove(at: minIdx)
+            if Self.studyDict.count > Self.maxStudyEntries {
+                let protectedCount = min(100, Self.studyDict.count)
+                let range = protectedCount..<Self.studyDict.count
+                if let minIdx = range.min(by: { Self.studyDict[$0].score() < Self.studyDict[$1].score() }) {
+                    Self.studyDict.remove(at: minIdx)
                 }
             }
         }
@@ -321,10 +337,10 @@ class WordSearch {
     /// Returns true if the entry was found and removed.
     @discardableResult
     func deleteFromStudy(word: String, reading: String) -> Bool {
-        let before = studyDict.count
-        studyDict.removeAll { $0.reading == reading && $0.word == word }
-        if studyDict.count < before {
-            Self.saveStudyDict(dictFile: studyDictFile, dict: studyDict)
+        let before = Self.studyDict.count
+        Self.studyDict.removeAll { $0.reading == reading && $0.word == word }
+        if Self.studyDict.count < before {
+            Self.saveStudyDict(dictFile: Self.studyDictFile, dict: Self.studyDict)
             Log.dict.info("Deleted from study dict: \"\(word)\" (reading: \"\(reading)\")")
             return true
         }
@@ -351,7 +367,7 @@ class WordSearch {
     }
 
     func finish() {
-        Self.saveStudyDict(dictFile: studyDictFile, dict: studyDict)
+        Self.saveStudyDict(dictFile: Self.studyDictFile, dict: Self.studyDict)
     }
 
     // MARK: - File I/O

--- a/GyaimSwift/Tests/GyaimTests/WordSearchTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/WordSearchTests.swift
@@ -14,6 +14,9 @@ final class WordSearchTests: XCTestCase {
         try "".write(to: localDict, atomically: true, encoding: .utf8)
         try "".write(to: studyDict, atomically: true, encoding: .utf8)
 
+        // static studyDict をリセットして各テストが独立した状態で始まるようにする
+        WordSearch.resetStudyDict()
+
         // Find dict.txt
         let projectDir = URL(fileURLWithPath: #file)
             .deletingLastPathComponent() // GyaimTests
@@ -228,6 +231,8 @@ final class WordSearchTests: XCTestCase {
         WordSearch.saveStudyDict(dictFile: studyPath, dict: entries)
 
         // 新しいWordSearchインスタンスで読み込み直し
+        // static studyDict をリセットしてファイルから再読み込みさせる
+        WordSearch.resetStudyDict()
         let projectDir = URL(fileURLWithPath: #file)
             .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
         let dictPath = projectDir.appendingPathComponent("Resources/dict.txt").path
@@ -281,6 +286,8 @@ final class WordSearchTests: XCTestCase {
 
         WordSearch.saveStudyDict(dictFile: studyPath, dict: entries)
 
+        // static studyDict をリセットしてファイルから再読み込みさせる
+        WordSearch.resetStudyDict()
         let projectDir = URL(fileURLWithPath: #file)
             .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
         let dictPath = projectDir.appendingPathComponent("Resources/dict.txt").path
@@ -628,5 +635,68 @@ final class WordSearchTests: XCTestCase {
         XCTAssertTrue(words.contains("設定"))
         XCTAssertFalse(words.contains("設定画面"),
             "Exact search mode should not include prefix-only matches")
+    }
+
+    // MARK: - Multi-Instance Study Dict Sharing (BUG-005)
+
+    /// BUG: 複数の GyaimController インスタンスがそれぞれ独自の WordSearch/studyDict を持つため、
+    /// あるインスタンスで study した語が、別インスタンスの saveStudyDict で上書きされて消える。
+    /// 修正後は全インスタンスが同一の studyDict メモリを共有すること。
+    func testStudyVisibleAcrossInstances() throws {
+        try XCTSkipIf(ws == nil)
+        let projectDir = URL(fileURLWithPath: #file)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        let dictPath = projectDir.appendingPathComponent("Resources/dict.txt").path
+        guard FileManager.default.fileExists(atPath: dictPath) else {
+            throw XCTSkip("dict.txt not found")
+        }
+
+        // ws (from setUp) と同じ studyDictFile を共有する別インスタンスを作成
+        let ws2 = WordSearch(connectionDictFile: dictPath,
+                             localDictFile: tempDir.appendingPathComponent("localdict.txt").path,
+                             studyDictFile: tempDir.appendingPathComponent("studydict.txt").path)
+
+        // ws で「乖離」を学習
+        ws.study(word: "乖離", reading: "kairi")
+        // ws2 で「修正」を学習
+        ws2.study(word: "修正", reading: "syuusei")
+
+        // ws2 の search で「乖離」が見えること（共有メモリ）
+        let results2 = ws2.search(query: "kairi", searchMode: 1)
+        XCTAssertTrue(results2.map(\.word).contains("乖離"),
+            "ws2 should see ws's studied word '乖離' via shared studyDict")
+
+        // ws の search で「修正」が見えること
+        let results1 = ws.search(query: "syuusei", searchMode: 1)
+        XCTAssertTrue(results1.map(\.word).contains("修正"),
+            "ws should see ws2's studied word '修正' via shared studyDict")
+    }
+
+    /// 別インスタンスの study が saveStudyDict で上書きされないこと。
+    func testStudySurvivesOtherInstanceSave() throws {
+        try XCTSkipIf(ws == nil)
+        let projectDir = URL(fileURLWithPath: #file)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        let dictPath = projectDir.appendingPathComponent("Resources/dict.txt").path
+        guard FileManager.default.fileExists(atPath: dictPath) else {
+            throw XCTSkip("dict.txt not found")
+        }
+
+        let ws2 = WordSearch(connectionDictFile: dictPath,
+                             localDictFile: tempDir.appendingPathComponent("localdict.txt").path,
+                             studyDictFile: tempDir.appendingPathComponent("studydict.txt").path)
+
+        // ws で「乖離」を学習（ファイルに保存される）
+        ws.study(word: "乖離", reading: "kairi")
+        // ws2 で「海里」を学習（ファイルに保存される）
+        ws2.study(word: "海里", reading: "kairi")
+
+        // ファイルをリロードして「乖離」が残っていること
+        let entries = WordSearch.loadStudyDict(
+            dictFile: tempDir.appendingPathComponent("studydict.txt").path)
+        XCTAssertTrue(entries.map(\.word).contains("乖離"),
+            "乖離 should survive in file after ws2.study() — must not be overwritten")
+        XCTAssertTrue(entries.map(\.word).contains("海里"),
+            "海里 should also be in file")
     }
 }

--- a/docs/specs/bug-memory.md
+++ b/docs/specs/bug-memory.md
@@ -1,7 +1,7 @@
 # Spec: バグメモリ
 
 > Trigger: 全ファイル（デバッグ時に参照）
-> Last updated: 2026-04-15 (BUG-004追加)
+> Last updated: 2026-04-16 (BUG-005追加)
 
 ## 概要
 
@@ -62,6 +62,22 @@
   - 「機能をONにしたが contract を満たさない」は ON/OFF 設定とは別の設計バグ。設定の有無ではなく**仕様の一貫性**を疑うべき
   - dedup の先着勝ちは `source` フィールドの整合性に直結する。priorityを変えるときは候補削除機能との連動を必ず確認
   - 辞書をまたいだランキング設計は connectionDict の static 単漢字を考慮しないと UX が劣化する。"all exact first" は素朴すぎる
+
+### BUG-005: 複数インスタンスの studyDict が互いの学習データを上書きして消す
+
+- **発見日**: 2026-04-16
+- **症状**: Google APIで「乖離」を確定しログにも `Studied: "乖離"` と記録されるが、時間が経つと候補リストに出てこなくなる。studydict.txt からエントリが消失
+- **影響**: あるアプリで学習した語が、別アプリ（別の GyaimController インスタンス）での study/save 時に上書きされて消える。BUG-003修正（保存タイミング）後も発生
+- **原因**: `studyDict` が `WordSearch` のインスタンス変数だった。InputMethodKit はクライアントアプリごとに別の `GyaimController`/`WordSearch` インスタンスを生成するため、各インスタンスが独立したメモリ上の `studyDict` を保持。インスタンスAで study した語が、インスタンスB の `saveStudyDict` 時にインスタンスBのメモリ（Aの学習を知らない）でファイルを上書きし消失
+- **修正**:
+  - `WordSearch.studyDict` と `studyDictFile` をインスタンス変数から **static 変数**（プロセス内共有）に変更
+  - init() は studyDictFile が異なる場合のみ再読み込み（テスト互換性）
+  - `resetStudyDict()` を追加（テスト間のアイソレーション用）
+- **検証**: `testStudyVisibleAcrossInstances`, `testStudySurvivesOtherInstanceSave` の2テスト追加
+- **教訓**:
+  - IMKInputController はクライアントアプリごとにインスタンスが生成される。共有状態（学習辞書等）をインスタンス変数にすると、マルチインスタンス間で不整合が起きる
+  - BUG-003（保存タイミング）の修正は必要条件だったが十分条件ではなかった。「保存しても消える」場合は、別インスタンスによる上書きを疑うべき
+  - ファイルを介した間接的な共有（各インスタンスが read → modify → write）は write-write 競合の温床。メモリ上で単一の真実を共有すべき
 
 ## パターン集
 

--- a/docs/specs/dictionary-system.md
+++ b/docs/specs/dictionary-system.md
@@ -1,7 +1,7 @@
 # Spec: 辞書システム
 
 > Trigger: WordSearch.swift, ConnectionDict.swift
-> Last updated: 2026-04-15 (ADR-017対応)
+> Last updated: 2026-04-16 (BUG-005: studyDict static化)
 
 ## 概要
 
@@ -121,6 +121,14 @@ SearchCandidateに`source`フィールドを追加し、各候補の出自を追
 dedup は `word` 単位の先着勝ちなので、user-owned dict (study/local) が先に列挙されることで `source = .connection` で上書きされず、Shift+X による候補削除（`GyaimController.deleteCurrentCandidate`）が機能する。
 
 OFF時は単一パス（study → local → connection）で従来どおり MRU 順。
+
+## studyDict のプロセス内共有（BUG-005）
+
+`studyDict` と `studyDictFile` は `WordSearch` の **static 変数**（プロセス全体で共有）。InputMethodKitはクライアントアプリごとに別の `GyaimController`/`WordSearch` インスタンスを生成するため、インスタンス変数にすると各インスタンスが独立したメモリを持ち、ある インスタンスの `saveStudyDict` が他インスタンスの学習データを上書きして消す。
+
+- init() は `studyDictFile` パスが変わった場合のみファイルから再読み込み
+- `resetStudyDict()` はテスト専用（テスト間のアイソレーション）
+- `localDict` はインスタンス変数のまま（mtime ホットリロードがあり、マルチインスタンスでの上書き問題は `register()` 頻度が低いため実害なし）
 
 ## 既知の制約
 


### PR DESCRIPTION
## Summary

- InputMethodKitがクライアントアプリごとに別の`GyaimController`/`WordSearch`インスタンスを生成するため、`studyDict`がインスタンス変数だと各インスタンスが独立したメモリを保持し、あるインスタンスの`saveStudyDict`が別インスタンスの学習データを上書きして消す問題を修正
- `WordSearch.studyDict`/`studyDictFile`を**static変数**（プロセス内共有）に変更し、全インスタンスが同一メモリを参照するようにした
- BUG-003（保存タイミング修正）後も「Google APIで確定した候補が時間経過で消える」現象が発生していた根本原因

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `WordSearch.swift` | `studyDict`/`studyDictFile`をstatic化、`resetStudyDict()`追加 |
| `WordSearchTests.swift` | テスト2件追加 + setUp/ws2テストにresetStudyDict()追加 |
| `bug-memory.md` | BUG-005エントリ追記 |
| `dictionary-system.md` | プロセス内共有の説明セクション追加 |

## 再現シナリオ

```
1. アプリAで GyaimController(A)/WordSearch(A) 起動 → studydict.txt 読み込み
2. アプリBで GyaimController(B)/WordSearch(B) 起動 → 同じファイル読み込み
3. アプリAで「乖離」を確定 → メモリA + ファイル保存 (乖離 ✓)
4. アプリBで何かを確定 → メモリB(乖離を知らない) + ファイル保存 → 乖離消失 ✗
```

## Test plan

- [x] 新規テスト `testStudyVisibleAcrossInstances` — 2つのインスタンス間でstudyが共有されること
- [x] 新規テスト `testStudySurvivesOtherInstanceSave` — 別インスタンスのsaveで学習データが消えないこと
- [x] 既存テスト218件全パス（リグレッションなし）
- [x] プロダクションビルド成功
- [ ] インストールして実機でGoogle API確定語の永続性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)