### PR TITLE
Fix local unit test execution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,7 @@ jobs:
 
       - name: Run tests
         working-directory: GyaimSwift
-        run: |
-          xcodebuild -project Gyaim.xcodeproj \
-            -scheme GyaimTests \
-            -derivedDataPath .build \
-            test
+        run: ./Scripts/run-unit-tests.sh
 
       - name: Build
         working-directory: GyaimSwift

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,4 @@ jobs:
 
       - name: Run tests
         working-directory: GyaimSwift
-        run: |
-          xcodebuild -project Gyaim.xcodeproj \
-            -scheme GyaimTests \
-            -derivedDataPath .build \
-            test
+        run: ./Scripts/run-unit-tests.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ gh pr create --title ... --body ...
 ```bash
 xcodegen generate
 xcodebuild -project Gyaim.xcodeproj -scheme Gyaim -configuration Debug -derivedDataPath .build build
-xcodebuild -project Gyaim.xcodeproj -scheme GyaimTests -derivedDataPath .build test
+./Scripts/run-unit-tests.sh
 ```
 
 E2Eテスト:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,8 @@ Bidirectional romaji-kana conversion with 350+ rules in `rklist`. Includes full-
 ### テスト実行
 
 ```bash
-# ユニットテスト（204テスト）
-xcodebuild -project Gyaim.xcodeproj -scheme GyaimTests -derivedDataPath .build test
+# ユニットテスト（222テスト）
+./Scripts/run-unit-tests.sh
 
 # E2Eテスト（アクセシビリティ権限必要、Gyaimインストール済みの状態で実行）
 xcodebuild -project Gyaim.xcodeproj -scheme GyaimE2ETests -derivedDataPath .build test
@@ -106,11 +106,11 @@ xcodebuild -project Gyaim.xcodeproj -scheme GyaimE2ETests -derivedDataPath .buil
 | HandleEventTests | Tests/GyaimTests/ | 45 | `routeEvent` 静的メソッドによるキー入力分岐の全網羅 |
 | GoogleTransliterateTests | Tests/GyaimTests/ | 20 | フィルタ・候補ビルド・セグメント結合・トリガー設定・タイムアウト |
 | ExternalCandidateTests | Tests/GyaimTests/ | 22 | `isValidExternalCandidate` + `buildPrefixCandidates` |
-| PreferencesWindowTests | Tests/GyaimTests/ | 15 | 設定画面UIテスト（トグル存在・初期状態・クリック操作・表示モード切替・淘汰方式） |
-| CandidateWindowTests | Tests/GyaimTests/ | 5 | 表示モード（リスト/クラシック）の切替・描画・最大候補数 |
+| PreferencesWindowTests | Tests/GyaimTests/ | 18 | 設定画面UIテスト（トグル存在・初期状態・クリック操作・表示モード切替・淘汰方式） |
+| CandidateWindowTests | Tests/GyaimTests/ | 26 | 表示モード（リスト/クラシック）の切替・描画・最大候補数・位置計算 |
 | CopyTextTests | Tests/GyaimTests/ | 7 | CopyText ファイルI/O + NSPasteboard.changeCount |
 | RomaKanaTests | Tests/GyaimTests/ | 18 | ローマ字⇔かな変換の双方向テスト |
-| WordSearchTests | Tests/GyaimTests/ | 34 | 辞書検索（前方一致・完全一致・登録・トリガーサフィックス・study・eviction・削除・ソースタグ） |
+| WordSearchTests | Tests/GyaimTests/ | 48 | 辞書検索（前方一致・完全一致・登録・トリガーサフィックス・study・eviction・削除・ソースタグ） |
 | StudyEntryTests | Tests/GyaimTests/ | 9 | StudyEntryスコア計算・EvictionMode・ファイルI/O |
 | CryptTests | Tests/GyaimTests/ | 6 | 暗号化/復号のラウンドトリップ |
 | ConnectionDictTests | Tests/GyaimTests/ | 3 | 連接辞書の検索 |

--- a/GyaimSwift/Scripts/run-unit-tests.sh
+++ b/GyaimSwift/Scripts/run-unit-tests.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT="${PROJECT:-Gyaim.xcodeproj}"
+SCHEME="${SCHEME:-GyaimTests}"
+DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-.build}"
+BUNDLE="$DERIVED_DATA_PATH/Build/Products/Debug/${SCHEME}.xctest"
+PROFILE_DIR="$DERIVED_DATA_PATH/Build/ProfileData"
+
+mkdir -p "$PROFILE_DIR"
+
+xcodebuild \
+  -project "$PROJECT" \
+  -scheme "$SCHEME" \
+  -derivedDataPath "$DERIVED_DATA_PATH" \
+  build-for-testing
+
+# Local macOS/Xcode combinations can attach com.apple.provenance to freshly
+# built .xctest bundles. In that state `xcodebuild test` may report
+# "Cannot find executable for CFBundle" even when Contents/MacOS/<test> exists.
+# Running the already-built bundle with xcrun xctest after clearing xattrs avoids
+# the loader failure while keeping the same XCTest bundle.
+/usr/bin/xattr -cr "$BUNDLE" 2>/dev/null || true
+
+LLVM_PROFILE_FILE="$PROFILE_DIR/${SCHEME}-%p.profraw" \
+  xcrun xctest "$BUNDLE"

--- a/GyaimSwift/project.yml
+++ b/GyaimSwift/project.yml
@@ -49,6 +49,7 @@ targets:
     settings:
       SWIFT_VERSION: "5.9"
       GENERATE_INFOPLIST_FILE: YES
+      INFOPLIST_FILE: ""
       PRODUCT_BUNDLE_IDENTIFIER: com.pitecan.inputmethod.SwiftyGyaim.Tests
       PRODUCT_MODULE_NAME: Gyaim
     frameworks:
@@ -63,6 +64,7 @@ targets:
     settings:
       SWIFT_VERSION: "5.9"
       GENERATE_INFOPLIST_FILE: YES
+      INFOPLIST_FILE: ""
       PRODUCT_BUNDLE_IDENTIFIER: com.pitecan.inputmethod.SwiftyGyaim.E2ETests
     frameworks:
       - Carbon

--- a/docs/specs/bug-memory.md
+++ b/docs/specs/bug-memory.md
@@ -1,7 +1,7 @@
 # Spec: バグメモリ
 
 > Trigger: 全ファイル（デバッグ時に参照）
-> Last updated: 2026-05-05 (BUG-006追加)
+> Last updated: 2026-05-05 (BUG-007追加)
 
 ## 概要
 
@@ -97,6 +97,24 @@
   - IMKTextInputが返す座標はクライアント依存で、常にスクリーン座標とは限らない
   - UI位置計算では「取得できた」だけでなく「スクリーン座標として妥当か」を検証する
   - フォールバック発生時にログで元値・解決後の値・選択元を確認できるようにする
+
+### BUG-007: ローカルXcodeでGyaimTests.xctestを読み込めない
+
+- **発見日**: 2026-05-05
+- **症状**: ローカル環境で `xcodebuild -project Gyaim.xcodeproj -scheme GyaimTests -derivedDataPath .build test` を実行すると、`GyaimTests.xctest` の `Contents/MacOS/GyaimTests` は存在するにもかかわらず `Cannot find executable for CFBundle` / `Failed to load the test bundle` で失敗する
+- **影響**: ローカルでユニットテストが実行できず、修正確認が困難になる。GitHub Actions では通る場合があり、環境差分として見落としやすい
+- **原因**:
+  - XcodeGen生成プロジェクトでテストターゲットにもアプリ用 `Resources/Info.plist` が `INFOPLIST_FILE` として入っており、テストバンドルにIMEアプリ用のInfo.plistキーが混入していた
+  - ローカルmacOS/Xcodeの組み合わせで生成直後の `.xctest` に `com.apple.provenance` 拡張属性が付き、`xcodebuild test` のローダーが実行ファイルなしとして誤報するケースがある
+- **修正**:
+  - `project.yml` の `GyaimTests` / `GyaimE2ETests` に `INFOPLIST_FILE: ""` を明示し、生成Info.plistだけを使う
+  - `Scripts/run-unit-tests.sh` を追加し、`build-for-testing` → `.xctest` のxattrクリア → `xcrun xctest` の順で実行する
+  - CI/Release workflow と agent向けテストコマンドを新スクリプトへ更新
+- **検証**: `./Scripts/run-unit-tests.sh` で 222 tests / 0 failures を確認
+- **教訓**:
+  - 「実行ファイルが見つからない」エラーでも、実際にはInfo.plist混入や拡張属性が原因のローダー失敗である場合がある
+  - XcodeGenでアプリソース/リソースをテストターゲットにも含める場合、アプリ用Info.plistをテストバンドルに流用しないこと
+  - macOSのローカルセキュリティ属性に起因するテスト実行問題は、`build-for-testing` と `xcrun xctest` の分離で切り分けやすい
 
 ## パターン集
 


### PR DESCRIPTION
## Summary
- add `Scripts/run-unit-tests.sh` to run unit tests via `build-for-testing` + xattr cleanup + `xcrun xctest`
- prevent app `Resources/Info.plist` from leaking into generated test bundle Info.plists
- switch CI/release workflows and agent docs to the new unit test script
- document the local XCTest loader failure as BUG-007

## Background
On the local macOS/Xcode environment, `xcodebuild ... test` failed with `Cannot find executable for CFBundle` even though `GyaimTests.xctest/Contents/MacOS/GyaimTests` existed. Clearing xattrs and invoking the built test bundle with `xcrun xctest` runs successfully.

## Testing
- `cd GyaimSwift && ./Scripts/run-unit-tests.sh` ✅
  - 222 tests, 0 failures
