### PR TITLE
Add internal architecture documentation

### DIFF
--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -4,13 +4,14 @@
 
 ## 読む順番
 
-1. [全体アーキテクチャ](architecture.md)
-2. [Swift / InputMethodKit で作る IME の概要](ime-api.md)
-3. [入力・変換・確定フロー](input-flow.md)
-4. [辞書・学習システム](dictionary-system.md)
-5. [候補ウィンドウとUI](candidate-window-and-ui.md)
-6. [機能別実装ガイド](feature-guide.md)
-7. [テスト・ビルド・運用](testing-and-operations.md)
+1. [ソースコードを読む: 実装ウォークスルー](source-walkthrough.md)
+2. [全体アーキテクチャ](architecture.md)
+3. [Swift / InputMethodKit で作る IME の概要](ime-api.md)
+4. [入力・変換・確定フロー](input-flow.md)
+5. [辞書・学習システム](dictionary-system.md)
+6. [候補ウィンドウとUI](candidate-window-and-ui.md)
+7. [機能別実装ガイド](feature-guide.md)
+8. [テスト・ビルド・運用](testing-and-operations.md)
 
 ## ソースコードの主な場所
 
@@ -40,4 +41,4 @@ GyaimSwift/
 - `docs/specs/`: 実装と同期する領域別仕様
 - `docs/adr/`: 設計判断の記録
 
-この `docs/internal/` は、上記よりも「初めて読む人が理解する」ことを重視した解説です。
+この `docs/internal/` は、上記よりも「初めて読む人が理解する」ことを重視した解説です。Swiftでアプリ開発をしたことがある人が、InputMethodKit固有の文脈とSwiftyGyaimの実装を追える粒度を目指しています。

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -1,0 +1,43 @@
+# SwiftyGyaim 内部設計ドキュメント
+
+このディレクトリは、SwiftyGyaim のソースコードを理解するための内部向けドキュメントです。実装を読む入口として、全体像、macOS IME API、主要機能ごとの処理フローをまとめています。
+
+## 読む順番
+
+1. [全体アーキテクチャ](architecture.md)
+2. [Swift / InputMethodKit で作る IME の概要](ime-api.md)
+3. [入力・変換・確定フロー](input-flow.md)
+4. [辞書・学習システム](dictionary-system.md)
+5. [候補ウィンドウとUI](candidate-window-and-ui.md)
+6. [機能別実装ガイド](feature-guide.md)
+7. [テスト・ビルド・運用](testing-and-operations.md)
+
+## ソースコードの主な場所
+
+```text
+GyaimSwift/
+├── project.yml                 # XcodeGen定義
+├── Resources/                  # Info.plist, dict.txt, アイコン等
+├── Sources/Gyaim/              # 本体実装
+│   ├── main.swift              # IMKServer起動
+│   ├── AppDelegate.swift       # アプリライフサイクル
+│   ├── GyaimController.swift   # IME入力処理の中心
+│   ├── WordSearch.swift        # 辞書検索・学習
+│   ├── ConnectionDict.swift    # 連接辞書
+│   ├── RomaKana.swift          # ローマ字かな変換
+│   ├── CandidateWindow.swift   # 候補ウィンドウ
+│   ├── PreferencesWindow.swift # 設定画面
+│   ├── DictEditorWindow.swift  # ユーザー辞書エディタ
+│   └── ...
+└── Tests/
+    ├── GyaimTests/             # ユニットテスト
+    └── E2ETests/               # E2Eテスト
+```
+
+## 関連ドキュメント
+
+- `CLAUDE.md` / `AGENTS.md`: agent 向け運用ルール
+- `docs/specs/`: 実装と同期する領域別仕様
+- `docs/adr/`: 設計判断の記録
+
+この `docs/internal/` は、上記よりも「初めて読む人が理解する」ことを重視した解説です。

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -1,0 +1,138 @@
+# 全体アーキテクチャ
+
+## 概要
+
+SwiftyGyaim は macOS の InputMethodKit を使った日本語 IME です。アプリとしては `LSBackgroundOnly` のバックグラウンドアプリとして動作し、入力ソースに選択されたときに `IMKInputController` のサブクラス `GyaimController` がキーイベントを受け取ります。
+
+大きく分けると、以下の責務に分かれます。
+
+| 領域 | 主なファイル | 役割 |
+|---|---|---|
+| IME起動 | `main.swift`, `AppDelegate.swift` | `IMKServer` 起動、ライフサイクル、終了時保存 |
+| 入力制御 | `GyaimController.swift` | キーイベント処理、変換状態管理、確定、候補表示制御 |
+| 変換 | `RomaKana.swift`, `WordSearch.swift`, `ConnectionDict.swift` | ローマ字かな変換、辞書検索、学習 |
+| 候補UI | `CandidateWindow.swift` | 非アクティブ候補ウィンドウ、表示モード、位置計算 |
+| 設定UI | `PreferencesWindow.swift`, `KeyBindings.swift` | ショートカット、候補設定、Google変換、学習設定 |
+| 辞書編集 | `DictEditorWindow.swift` | `~/.gyaim/localdict.txt` の編集 |
+| 外部候補 | `CopyText.swift`, `GoogleTransliterate.swift` | クリップボード/選択テキスト/Google候補 |
+| ログ | `GyaimLogger.swift` | os.Logger とファイルログ |
+
+## プロセス構成
+
+```text
+macOS Input Source
+      │
+      ▼
+SwiftyGyaim.app  (LSBackgroundOnly)
+      │
+      ├─ main.swift
+      │   └─ IMKServer(name: "Gyaim_Connection", bundleIdentifier: ...)
+      │
+      ├─ AppDelegate
+      │   ├─ Config.setup()
+      │   ├─ クリップボード定期ポーリング
+      │   └─ 終了時 study dict 保存 / ログflush
+      │
+      └─ GyaimController (IMKInputController)
+          ├─ handle(_:client:) でキー入力を受ける
+          ├─ WordSearch で候補検索
+          ├─ CandidateWindow に候補を表示
+          └─ IMKTextInput.insertText / setMarkedText でクライアントへ反映
+```
+
+## 中心となる状態
+
+`GyaimController` が IME の入力状態を持ちます。
+
+| 変数 | 意味 |
+|---|---|
+| `inputPat` | 現在入力中のローマ字パターン |
+| `candidates` | 現在の候補配列 |
+| `nthCand` | 選択中候補のインデックス |
+| `searchMode` | `0=前方一致`, `1=完全一致`, `2=Google結果` |
+| `clipboardCandidate` | 入力開始時点のクリップボード候補 |
+| `selectedCandidate` | 入力開始時点の選択テキスト候補 |
+| `pendingGoogleQuery` | Google変換のstale guard用クエリ |
+
+`converting` は `!inputPat.isEmpty` の computed property です。
+
+## 入力から候補表示までの大まかな流れ
+
+```text
+NSEvent keyDown
+  │
+  ▼
+GyaimController.handle(_:client:)
+  │
+  ├─ ショートカット判定
+  │   ├─ ひらがな確定
+  │   ├─ カタカナ確定
+  │   ├─ Google変換
+  │   └─ 候補削除
+  │
+  ├─ 通常キー処理
+  │   ├─ ローマ字を inputPat に追加
+  │   ├─ Backspace / Escape / Space / Enter / 数字キー処理
+  │   └─ searchAndShowCands()
+  │
+  ▼
+WordSearch.search(query:searchMode:)
+  │
+  ├─ studyDict
+  ├─ localDict
+  └─ connectionDict
+  │
+  ▼
+GyaimController.showCands()
+  │
+  ├─ 候補ページング
+  ├─ ひらがな/カタカナ fallback
+  └─ CandidateWindow.updateCandidates()
+```
+
+## データ保存先
+
+ユーザーデータは `~/.gyaim/` に保存されます。
+
+| ファイル | 用途 |
+|---|---|
+| `localdict.txt` | ユーザー辞書。形式: `reading<TAB>word` |
+| `studydict.txt` | 学習辞書。形式: `reading<TAB>word<TAB>timestamp<TAB>frequency` |
+| `copytext` | クリップボード候補用キャッシュ |
+| `gyaim.log` | ファイルログ |
+
+固定辞書はアプリバンドル内の `Resources/dict.txt` です。
+
+## 設計上の重要な制約
+
+### LSBackgroundOnly
+
+IMEアプリは通常の前面アプリではありません。`NSApp.unhide(nil)` のような通常アプリ向け操作は入力先アプリからフォーカスを奪うため禁止です。
+
+設定画面や辞書エディタを開く場合だけ `NSApp.setActivationPolicy(.accessory)` にして、閉じると `.prohibited` に戻します。
+
+### 候補ウィンドウは non-activating panel
+
+`CandidateWindow` は `NSPanel` の `.nonactivatingPanel` です。通常の `NSWindow` にすると候補表示のために入力先アプリのフォーカスを奪う可能性があります。
+
+### IMKInputController は複数インスタンスになり得る
+
+InputMethodKit はクライアントアプリごとに `GyaimController` を生成することがあります。学習辞書のようにプロセス全体で共有すべき状態は static に置く必要があります。`WordSearch.studyDict` はこの理由で static です。
+
+## 主要な依存関係
+
+```text
+GyaimController
+  ├─ WordSearch
+  │   ├─ ConnectionDict
+  │   ├─ StudyEntry / EvictionMode
+  │   └─ GoogleTransliterate.hasTriggerSuffix
+  ├─ RomaKana
+  ├─ CandidateWindow
+  ├─ KeyBindings
+  ├─ CopyText / ClipboardMonitor
+  ├─ PreferencesWindow / DictEditorWindow
+  └─ GyaimLogger
+```
+
+`GyaimController` が多数の機能を束ねる中心クラスです。機能追加時は、状態遷移・候補再検索・UI更新・学習の副作用がすべてここに集まりやすい点に注意します。

--- a/docs/internal/candidate-window-and-ui.md
+++ b/docs/internal/candidate-window-and-ui.md
@@ -1,170 +1,319 @@
 # 候補ウィンドウとUI
 
-## 中心ファイル
+このドキュメントでは `CandidateWindow.swift` と `GyaimController.showWindow()` を実装寄りに読みます。IMEのUIで最も重要なのは「入力先アプリのフォーカスを奪わない」ことです。
 
-- `CandidateWindow.swift`
-- `GyaimController.swift`
-- `PreferencesWindow.swift`
-- `DictEditorWindow.swift`
-
-## CandidateWindow の役割
-
-`CandidateWindow` は変換候補を表示する `NSPanel` です。
-
-重要な設定:
+## 1. `CandidateWindow` は `NSPanel`
 
 ```swift
-styleMask: [.borderless, .nonactivatingPanel]
+class CandidateWindow: NSPanel {
+    static var shared: CandidateWindow?
+    ...
+}
+```
+
+初期化では `.nonactivatingPanel` を指定しています。
+
+```swift
+super.init(contentRect: frame,
+           styleMask: [.borderless, .nonactivatingPanel],
+           backing: .buffered,
+           defer: false)
+
+becomesKeyOnlyIfNeeded = true
 level = .statusBar
-backgroundColor = .clear
 isOpaque = false
+hasShadow = true
+hidesOnDeactivate = false
 ```
 
-`.nonactivatingPanel` により、入力先アプリのフォーカスを奪わずに候補を表示できます。
+通常の `NSWindow` やactivateするpanelを使うと、候補表示のたびに入力先アプリからフォーカスを奪う可能性があります。IMEの候補ウィンドウではこれが致命的です。
 
-## 表示モード
-
-`CandidateDisplayMode` は2種類です。
-
-| モード | 値 | 表示数 | 見た目 |
-|---|---:|---:|---|
-| `.list` | 0 | 9 | 縦リスト、番号付き、ハイライト行 |
-| `.classic` | 1 | 11 | オリジナルGyaim風、`candwin.png` 背景、横並び |
-
-現在の設定は `UserDefaults` の `candidateDisplayMode` から読みます。デフォルトは `.classic` です。
-
-## view構成
-
-```text
-CandidateWindow(NSPanel)
-└─ containerView
-   ├─ list mode
-   │  └─ NSStackView
-   │     └─ NSTextField labels
-   │
-   └─ classic mode
-      ├─ ClassicBackgroundView
-      └─ classicContentView
-         └─ NSScrollView
-            └─ NSTextView
-```
-
-`applyDisplayMode()` でlist用制約とclassic用制約を切り替えます。
-
-## 候補更新
-
-`GyaimController.showCands()` が表示対象候補をページングし、`CandidateWindow.updateCandidates()` に渡します。
+## 2. 表示モードは enum と UserDefaults
 
 ```swift
-func updateCandidates(_ words: [String], selectedIndex: Int,
-                      hasMore: Bool = false, hasPrev: Bool = false)
+enum CandidateDisplayMode: Int {
+    case list = 0
+    case classic = 1
+
+    static var current: CandidateDisplayMode {
+        let raw = UserDefaults.standard.object(forKey: "candidateDisplayMode") as? Int ?? 1
+        return CandidateDisplayMode(rawValue: raw) ?? .classic
+    }
+}
 ```
 
-`hasMore` がtrueなら、末尾に `▼` を表示します。
+デフォルトは `.classic` です。表示数もenumに持たせています。
 
-- list: indicator labelを追加
-- classic: テキスト末尾に `▼`
+```swift
+var maxVisible: Int {
+    switch self {
+    case .list: return 9
+    case .classic: return 11
+    }
+}
+```
 
-`hasPrev` は将来拡張用で、現在のUIでは表示に使いません。
+この値は `GyaimController.showCands()` のページングにも使われます。UIクラスだけでなく入力フローにも影響する設定です。
 
-## ページング
+## 3. view階層
 
-`nthCand` は全候補配列上の選択位置です。候補ウィンドウには `nthCand + 1` から最大表示数ぶんの候補を渡します。
+`CandidateWindow` はlistとclassicの両方のviewを持ち、表示モードごとに hidden と制約を切り替えます。
 
 ```text
-candidates: [0, 1, 2, 3, 4, ...]
-selected nthCand = 3
-window receives candidates[4..<4+maxVisible]
+containerView
+├─ stackView                  # list mode
+├─ ClassicBackgroundView       # classic mode background
+└─ classicContentView
+   └─ classicScrollView
+      └─ classicTextView
 ```
 
-この設計では、0番目候補を「入力そのもの」や補助候補として扱いつつ、スペースで次候補へ進む動きになります。
+`setupListMode()` と `setupClassicMode()` は起動時に両方呼ばれます。その後 `applyDisplayMode()` で片方だけ有効化します。
 
-## 位置計算
+```swift
+NSLayoutConstraint.deactivate(listConstraints)
+NSLayoutConstraint.deactivate(classicConstraints)
 
-位置計算は `CandidateWindowPositioner` に分離され、ユニットテスト可能です。
+stackView.isHidden = !isList
+classicBackgroundView?.isHidden = isList
+...
 
-主な関数:
+if isList {
+    NSLayoutConstraint.activate(listConstraints)
+} else {
+    NSLayoutConstraint.activate(classicConstraints)
+}
+```
 
-| 関数 | 役割 |
+毎回viewを作り直さず、制約セットを切り替える実装です。
+
+## 4. list mode の実装
+
+list mode は `NSStackView` に `NSTextField` を並べます。
+
+```swift
+private func updateListMode(_ words: [String], selectedIndex: Int, hasMore: Bool, hasPrev: Bool) {
+    candidateLabels.forEach { $0.removeFromSuperview() }
+    candidateLabels.removeAll()
+
+    let count = min(words.count, CandidateDisplayMode.list.maxVisible)
+    for i in 0..<count {
+        let label = makeLabel(index: i, word: words[i], isSelected: i == selectedIndex)
+        stackView.addArrangedSubview(label)
+        candidateLabels.append(label)
+    }
+}
+```
+
+`makeLabel` で番号や選択ハイライトを作ります。`hasMore` がtrueなら `▼` indicatorを末尾に追加します。
+
+## 5. classic mode の実装
+
+classic mode はオリジナルGyaim風の吹き出し画像 `candwin.png` を背景に使います。
+
+```swift
+private var classicBackgroundView: ClassicBackgroundView?
+private var classicScrollView: NSScrollView?
+private var classicTextView: NSTextView?
+```
+
+候補は横並びのテキストとして `NSTextView` に入れます。背景は `ClassicBackgroundView.draw(_:)` で9-slice的に描画し、角やtailを壊さず中央を伸ばします。
+
+classicは見た目のためにウィンドウshadowを切ります。
+
+```swift
+hasShadow = false
+```
+
+`candwin.png` 自体に影があるため、NSWindowのshadowを重ねると二重になります。
+
+## 6. 候補ウィンドウに渡される候補は「次候補」
+
+`GyaimController.showCands()` は、現在選択中の候補を入力先アプリの marked text に出し、候補ウィンドウにはその次から渡します。
+
+```swift
+let maxCandList = CandidateDisplayMode.current.maxVisible
+var candList: [String] = []
+for i in 0..<maxCandList {
+    let idx = nthCand + 1 + i
+    guard idx < words.count else { break }
+    candList.append(words[idx])
+}
+
+candWindow?.updateCandidates(candList, selectedIndex: -1, hasMore: hasMore, hasPrev: hasPrev)
+```
+
+そのため、候補ウィンドウ内の `1` は `candidates[nthCand + 1]` に対応します。数字キー選択でも `targetIndex = nthCand + num` としているのはこのためです。
+
+## 7. 位置計算は `CandidateWindowPositioner`
+
+位置計算は `CandidateWindowPositioner` に集約されています。
+
+```swift
+struct CandidateWindowPositioner {
+    static func resolveLineRect(...)
+    static func isUsableReportedLineRect(...)
+    static func calculate(...)
+}
+```
+
+これはUI部品そのものから位置計算を切り出して、ユニットテストしやすくするためです。
+
+## 8. `showWindow()` の実装
+
+`GyaimController.showWindow()` は、まず入力先アプリからキャレット位置を取ります。
+
+```swift
+var reportedLineRect = NSRect.zero
+client.attributes(forCharacterIndex: 0, lineHeightRectangle: &reportedLineRect)
+```
+
+次に、この値を検証します。
+
+```swift
+let resolution = CandidateWindowPositioner.resolveLineRect(
+    reportedLineRect: reportedLineRect,
+    previousValidLineRect: lastValidCandidateLineRect,
+    mouseLocation: NSEvent.mouseLocation)
+```
+
+`resolution.source` は次のいずれかです。
+
+| source | 意味 |
 |---|---|
-| `resolveLineRect()` | IMKが返したlineRectの妥当性検証とfallback |
-| `isUsableReportedLineRect()` | 原点付近の怪しいrectを検出 |
-| `calculate()` | rect, window size, screen frameから表示originを計算 |
+| `.reported` | IMKが返した値をそのまま使用 |
+| `.previousValid` | 前回正常値へfallback |
+| `.mouseLocation` | マウス位置へfallback |
 
-### 位置決定の流れ
+`.reported` の場合だけ次回用に保存します。
 
-```text
-GyaimController.showWindow()
-  │
-  ├─ client.attributes(... lineHeightRectangle: &reportedLineRect)
-  │
-  ├─ CandidateWindowPositioner.resolveLineRect()
-  │   ├─ 正常なら reportedLineRect
-  │   ├─ 不正なら lastValidCandidateLineRect
-  │   └─ それも無ければ NSEvent.mouseLocation
-  │
-  ├─ 対象スクリーンの visibleFrame を決定
-  │
-  ├─ CandidateWindowPositioner.calculate()
-  │   ├─ 基本はカーソル下
-  │   ├─ 下に収まらなければ上へflip
-  │   └─ visibleFrame内にclamp
-  │
-  └─ cw.setFrameOrigin(origin)
+```swift
+if resolution.source == .reported {
+    lastValidCandidateLineRect = resolution.lineRect
+}
 ```
 
-### lineRect fallback
+## 9. 不正な lineRect の判定
 
-一部のブラウザ/Webアプリでは、`attributes(forCharacterIndex:lineHeightRectangle:)` がスクリーン座標ではなくビュー原点付近のローカル座標を返します。
-
-観測例:
+Webアプリでは次のような値が返ることがあります。
 
 ```text
 (34.0, 10.0, 1.0, 14.0)
 (60.0, 10.0, 1.0, 14.0)
 ```
 
-この値をそのまま使うと候補ウィンドウが画面左下付近に表示されます。現在は「原点付近・1px幅・通常行高程度」を疑わしいrectとして扱います。
+これはスクリーン座標ではなく、入力要素内のローカル座標に見えます。実装では次の特徴を持つrectを疑わしいものとして扱います。
 
-## Mozc実装との対応
+```swift
+let looksLikeClientLocalOriginRect = lineRect.minX >= 0
+    && lineRect.minY >= 0
+    && lineRect.minX < 64
+    && lineRect.minY < 64
+    && lineRect.width <= 2
+    && lineRect.height >= 8
+    && lineRect.height <= 40
+```
 
-Mozc の候補ウィンドウ位置決定も、preedit rect / target point と対象モニタの working area を使います。
+「原点付近」「caretらしい1px幅」「通常の行高程度」の組み合わせです。
 
-- 下に収まらなければ上へ逃がす
-- それでも収まらなければworking area内にクランプ
-- 対象displayを選ぶ
+## 10. スクリーン選択
 
-SwiftyGyaim も `NSScreen.visibleFrame` を使って同様にクランプします。ただし IMKクライアントがローカル座標を返す問題があるため、Mozcより一段前で `lineRect` 検証を追加しています。
+位置計算に使うscreen frameは `NSScreen.main` 固定ではありません。
 
-## PreferencesWindow
+```swift
+let screenFrame = NSScreen.screens.first { $0.frame.intersects(resolution.lineRect) }?.visibleFrame
+    ?? NSScreen.screens.first { $0.frame.contains(NSEvent.mouseLocation) }?.visibleFrame
+    ?? NSScreen.main?.visibleFrame
+    ?? .zero
+```
 
-`PreferencesWindow` は設定画面です。
+優先順:
 
-設定項目:
+1. 解決後lineRectと交差するscreen
+2. マウス位置を含むscreen
+3. main screen
 
-| セクション | 内容 |
-|---|---|
-| キーボードショートカット | ひらがな/カタカナ確定、Google変換、候補削除 |
-| 候補 | 表示スタイル、クリップボード候補、選択テキスト候補 |
-| 学習辞書 | 淘汰方式、平仮名学習、完全一致reading優先 |
-| Google変換 | トリガー文字、ショートカット |
-| ログ | ログ有効化、削除、Finder表示 |
+`visibleFrame` を使うので、メニューバーやDock領域を避けやすくなります。
 
-`PreferencesWindow.show()` では `.accessory` に切り替えて前面表示し、`close()` で `.prohibited` に戻します。
+## 11. `calculate()` の挙動
 
-## DictEditorWindow
+```swift
+var y = lineRect.origin.y - winSize.height - gap
 
-`DictEditorWindow` は `~/.gyaim/localdict.txt` の編集UIです。
+if y < screenFrame.minY {
+    y = lineRect.origin.y + lineRect.height + gap
+}
 
-- `NSTableView` で reading / word を編集
-- 追加・削除・保存・再読込ボタン
-- 保存時は `WordSearch.saveDict()` を使う
-- `WordSearch.search()` はmtime hot reloadするため、保存後は変換候補に反映されます
+if y + winSize.height > screenFrame.maxY {
+    y = screenFrame.maxY - winSize.height
+}
+if y < screenFrame.minY {
+    y = screenFrame.minY
+}
+```
 
-## UI実装の注意点
+基本はカーソルの下に出します。下に収まらなければ上に出します。それでも収まらなければscreen内にclampします。
 
-- 候補ウィンドウはフォーカスを奪わないことが最優先
-- 設定系ウィンドウだけ activation policy を切り替える
-- 候補表示モード切替では制約のactivate/deactivateを正しく行う
-- 候補ウィンドウ位置は `NSScreen.main` 固定ではなく、対象rect/マウス位置のスクリーンを使う
-- `lineRect` は取得できても正しいとは限らない
+x方向も同じようにclampします。
+
+```swift
+var x = lineRect.origin.x - (mode == .list ? 5 : 0)
+if x + winSize.width > screenFrame.maxX {
+    x = screenFrame.maxX - winSize.width
+}
+if x < screenFrame.minX {
+    x = screenFrame.minX
+}
+```
+
+## 12. PreferencesWindow の実装
+
+設定画面は通常の `NSWindow` です。ただしIMEは `LSBackgroundOnly` なので、表示時だけactivation policyを変えます。
+
+```swift
+static func show() {
+    ...
+    NSApp.setActivationPolicy(.accessory)
+    NSApp.activate(ignoringOtherApps: true)
+}
+
+override func close() {
+    super.close()
+    NSApp.setActivationPolicy(.prohibited)
+}
+```
+
+UIはコードで組み立てています。各設定は対応する型のstatic setterに流れます。
+
+例:
+
+- 表示モード → `CandidateDisplayMode.setCurrent()`
+- Google suffix → `GoogleTransliterate.setTriggerSuffix()`
+- 学習設定 → `WordSearch.setStudyHiraganaEnabled()`
+- 淘汰方式 → `EvictionMode.setCurrent()`
+
+## 13. DictEditorWindow の実装
+
+ユーザー辞書エディタは `NSTableViewDataSource` / `NSTableViewDelegate` を実装した `NSWindow` です。
+
+内部状態:
+
+```swift
+private var entries: [(reading: String, word: String)] = []
+```
+
+保存時は `entries` から空白をtrimし、空行を除いて `WordSearch.saveDict()` に渡します。
+
+```swift
+var dict: [[String]] = []
+for e in entries {
+    let r = e.reading.trimmingCharacters(in: .whitespaces)
+    let w = e.word.trimmingCharacters(in: .whitespaces)
+    if !r.isEmpty, !w.isEmpty {
+        dict.append([r, w])
+    }
+}
+WordSearch.saveDict(dictFile: Config.localDictFile, dict: dict)
+```
+
+`WordSearch.search()` はmtimeを見てlocal辞書をreloadするので、保存後すぐに変換候補へ反映されます。

--- a/docs/internal/candidate-window-and-ui.md
+++ b/docs/internal/candidate-window-and-ui.md
@@ -1,0 +1,170 @@
+# 候補ウィンドウとUI
+
+## 中心ファイル
+
+- `CandidateWindow.swift`
+- `GyaimController.swift`
+- `PreferencesWindow.swift`
+- `DictEditorWindow.swift`
+
+## CandidateWindow の役割
+
+`CandidateWindow` は変換候補を表示する `NSPanel` です。
+
+重要な設定:
+
+```swift
+styleMask: [.borderless, .nonactivatingPanel]
+level = .statusBar
+backgroundColor = .clear
+isOpaque = false
+```
+
+`.nonactivatingPanel` により、入力先アプリのフォーカスを奪わずに候補を表示できます。
+
+## 表示モード
+
+`CandidateDisplayMode` は2種類です。
+
+| モード | 値 | 表示数 | 見た目 |
+|---|---:|---:|---|
+| `.list` | 0 | 9 | 縦リスト、番号付き、ハイライト行 |
+| `.classic` | 1 | 11 | オリジナルGyaim風、`candwin.png` 背景、横並び |
+
+現在の設定は `UserDefaults` の `candidateDisplayMode` から読みます。デフォルトは `.classic` です。
+
+## view構成
+
+```text
+CandidateWindow(NSPanel)
+└─ containerView
+   ├─ list mode
+   │  └─ NSStackView
+   │     └─ NSTextField labels
+   │
+   └─ classic mode
+      ├─ ClassicBackgroundView
+      └─ classicContentView
+         └─ NSScrollView
+            └─ NSTextView
+```
+
+`applyDisplayMode()` でlist用制約とclassic用制約を切り替えます。
+
+## 候補更新
+
+`GyaimController.showCands()` が表示対象候補をページングし、`CandidateWindow.updateCandidates()` に渡します。
+
+```swift
+func updateCandidates(_ words: [String], selectedIndex: Int,
+                      hasMore: Bool = false, hasPrev: Bool = false)
+```
+
+`hasMore` がtrueなら、末尾に `▼` を表示します。
+
+- list: indicator labelを追加
+- classic: テキスト末尾に `▼`
+
+`hasPrev` は将来拡張用で、現在のUIでは表示に使いません。
+
+## ページング
+
+`nthCand` は全候補配列上の選択位置です。候補ウィンドウには `nthCand + 1` から最大表示数ぶんの候補を渡します。
+
+```text
+candidates: [0, 1, 2, 3, 4, ...]
+selected nthCand = 3
+window receives candidates[4..<4+maxVisible]
+```
+
+この設計では、0番目候補を「入力そのもの」や補助候補として扱いつつ、スペースで次候補へ進む動きになります。
+
+## 位置計算
+
+位置計算は `CandidateWindowPositioner` に分離され、ユニットテスト可能です。
+
+主な関数:
+
+| 関数 | 役割 |
+|---|---|
+| `resolveLineRect()` | IMKが返したlineRectの妥当性検証とfallback |
+| `isUsableReportedLineRect()` | 原点付近の怪しいrectを検出 |
+| `calculate()` | rect, window size, screen frameから表示originを計算 |
+
+### 位置決定の流れ
+
+```text
+GyaimController.showWindow()
+  │
+  ├─ client.attributes(... lineHeightRectangle: &reportedLineRect)
+  │
+  ├─ CandidateWindowPositioner.resolveLineRect()
+  │   ├─ 正常なら reportedLineRect
+  │   ├─ 不正なら lastValidCandidateLineRect
+  │   └─ それも無ければ NSEvent.mouseLocation
+  │
+  ├─ 対象スクリーンの visibleFrame を決定
+  │
+  ├─ CandidateWindowPositioner.calculate()
+  │   ├─ 基本はカーソル下
+  │   ├─ 下に収まらなければ上へflip
+  │   └─ visibleFrame内にclamp
+  │
+  └─ cw.setFrameOrigin(origin)
+```
+
+### lineRect fallback
+
+一部のブラウザ/Webアプリでは、`attributes(forCharacterIndex:lineHeightRectangle:)` がスクリーン座標ではなくビュー原点付近のローカル座標を返します。
+
+観測例:
+
+```text
+(34.0, 10.0, 1.0, 14.0)
+(60.0, 10.0, 1.0, 14.0)
+```
+
+この値をそのまま使うと候補ウィンドウが画面左下付近に表示されます。現在は「原点付近・1px幅・通常行高程度」を疑わしいrectとして扱います。
+
+## Mozc実装との対応
+
+Mozc の候補ウィンドウ位置決定も、preedit rect / target point と対象モニタの working area を使います。
+
+- 下に収まらなければ上へ逃がす
+- それでも収まらなければworking area内にクランプ
+- 対象displayを選ぶ
+
+SwiftyGyaim も `NSScreen.visibleFrame` を使って同様にクランプします。ただし IMKクライアントがローカル座標を返す問題があるため、Mozcより一段前で `lineRect` 検証を追加しています。
+
+## PreferencesWindow
+
+`PreferencesWindow` は設定画面です。
+
+設定項目:
+
+| セクション | 内容 |
+|---|---|
+| キーボードショートカット | ひらがな/カタカナ確定、Google変換、候補削除 |
+| 候補 | 表示スタイル、クリップボード候補、選択テキスト候補 |
+| 学習辞書 | 淘汰方式、平仮名学習、完全一致reading優先 |
+| Google変換 | トリガー文字、ショートカット |
+| ログ | ログ有効化、削除、Finder表示 |
+
+`PreferencesWindow.show()` では `.accessory` に切り替えて前面表示し、`close()` で `.prohibited` に戻します。
+
+## DictEditorWindow
+
+`DictEditorWindow` は `~/.gyaim/localdict.txt` の編集UIです。
+
+- `NSTableView` で reading / word を編集
+- 追加・削除・保存・再読込ボタン
+- 保存時は `WordSearch.saveDict()` を使う
+- `WordSearch.search()` はmtime hot reloadするため、保存後は変換候補に反映されます
+
+## UI実装の注意点
+
+- 候補ウィンドウはフォーカスを奪わないことが最優先
+- 設定系ウィンドウだけ activation policy を切り替える
+- 候補表示モード切替では制約のactivate/deactivateを正しく行う
+- 候補ウィンドウ位置は `NSScreen.main` 固定ではなく、対象rect/マウス位置のスクリーンを使う
+- `lineRect` は取得できても正しいとは限らない

--- a/docs/internal/dictionary-system.md
+++ b/docs/internal/dictionary-system.md
@@ -1,0 +1,203 @@
+# 辞書・学習システム
+
+## 中心ファイル
+
+- `WordSearch.swift`
+- `ConnectionDict.swift`
+- `StudyEntry.swift`
+- `RomaKana.swift`
+- `DictEditorWindow.swift`
+
+SwiftyGyaim の変換候補は、主に3層の辞書から作られます。
+
+## 3層辞書
+
+| 優先度 | 辞書 | 実装 | 保存先 | 特徴 |
+|---|---|---|---|---|
+| 1 | Study辞書 | `WordSearch.studyDict` | `~/.gyaim/studydict.txt` | 確定履歴による学習 |
+| 2 | Local辞書 | `WordSearch.localDict` | `~/.gyaim/localdict.txt` | ユーザー登録語 |
+| 3 | Connection辞書 | `ConnectionDict` | `Resources/dict.txt` | 固定辞書・連接対応 |
+
+候補は `SearchCandidate` として表現されます。
+
+```swift
+struct SearchCandidate: Equatable {
+    let word: String
+    let reading: String?
+    let source: CandidateSource
+}
+```
+
+`source` は候補削除可否やUI判断に使われます。
+
+## SearchCandidate.source
+
+| source | 意味 | 削除可否 |
+|---|---|---|
+| `.study` | 学習辞書由来 | 可 |
+| `.local` | ユーザー辞書由来 | 可 |
+| `.connection` | 固定連接辞書由来 | 不可 |
+| `.external` | クリップボード/選択テキスト等 | 不可 |
+| `.synthetic` | 入力文字列、かなfallback、タイムスタンプ等 | 不可 |
+
+## `WordSearch.search()`
+
+入口は次です。
+
+```swift
+func search(query: String, searchMode: Int, limit: Int = 0) -> [SearchCandidate]
+```
+
+`searchMode`:
+
+| 値 | 意味 |
+|---|---|
+| `0` | 前方一致。インクリメンタル候補 |
+| `1` | 完全一致。Space等で明示的に変換 |
+| `2` | Google結果表示。辞書検索自体はcontroller側で扱う |
+
+処理順:
+
+1. 空クエリなら空配列
+2. local辞書のmtimeを確認し、更新されていれば再読込
+3. 特殊入力を処理
+   - Googleトリガーsuffix
+   - `#`, `!`
+   - `ds` タイムスタンプ
+   - 大文字含み入力
+4. Study / Local / Connection を検索
+5. 重複候補を `word` 単位で除外
+
+## 完全一致reading優先
+
+設定 `exactReadingMatchPriority` がONかつ `searchMode == 0` の場合、前方一致候補の並びを4バケットに分けます。
+
+```text
+1. studyDict exact
+2. localDict exact
+3. studyDict prefix
+4. localDict prefix
+5. connectionDict
+```
+
+これは、短い読みの完全一致候補が長いprefix候補に埋もれる問題を避けるためです。
+
+Connection辞書は最後に単一パスで検索します。固定辞書の単漢字exactを先に出すと、学習済みprefix候補を押し流すためです。
+
+## ConnectionDict
+
+`ConnectionDict` は `Resources/dict.txt` を読み込む固定辞書です。
+
+形式:
+
+```text
+romaji<TAB>surface<TAB>input_connection<TAB>output_connection
+```
+
+内部では以下のリンクを作ります。
+
+| リンク | 用途 |
+|---|---|
+| `keyLink` | 読みの先頭文字から候補リストへ辿る |
+| `connectionLink` | `inConnection` 値から連接可能候補へ辿る |
+
+検索は `generateCand()` の再帰で行われます。
+
+```text
+pat が entry.pat と一致
+  → 候補を返す
+
+entry.pat が pat から始まる
+  → searchMode=0 ならprefix候補として返す
+
+pat が entry.pat から始まる
+  → 残りpatを outConnection で再帰検索
+```
+
+これにより、単語を連結した複合候補を生成できます。
+
+## Study辞書
+
+`StudyEntry` は以下を持ちます。
+
+| フィールド | 意味 |
+|---|---|
+| `reading` | ローマ字読み |
+| `word` | 確定語 |
+| `lastAccessTime` | 最終使用時刻 |
+| `frequency` | 使用回数 |
+
+保存形式:
+
+```text
+reading<TAB>word<TAB>timestamp<TAB>frequency
+```
+
+旧2カラム形式も読み込み可能です。
+
+## `WordSearch.study()`
+
+通常確定時に呼ばれます。
+
+主な処理:
+
+1. 平仮名学習設定を確認
+2. 既存entryなら頻度・時刻更新し先頭へ移動
+3. 新規entryなら先頭に追加
+4. 上限超過時にevict
+5. 即時ファイル保存
+6. 必要に応じてlocal辞書へ昇格
+
+`studyDict` は static です。InputMethodKit がクライアントごとに `GyaimController` / `WordSearch` を作るため、インスタンス変数にすると別インスタンスの保存で学習データが消えるからです。
+
+## EvictionMode
+
+`StudyEntry.score()` は Mozc風の簡易スコアです。
+
+```text
+score = lastAccessTime + log2(frequency) * 3600 - word.count * 600
+```
+
+| モード | 内容 |
+|---|---|
+| `.mru` | 最近使った順。末尾を削る |
+| `.none` | 淘汰なし。ただし実装上の上限処理は残る |
+| `.scoreBased` | 先頭一定件数を保護し、スコア最低のものを削る |
+
+## Local辞書
+
+`~/.gyaim/localdict.txt` に保存されます。
+
+形式:
+
+```text
+reading<TAB>word
+```
+
+`DictEditorWindow` で編集できます。`WordSearch.search()` は検索前にmtimeを見て、ファイルが更新されていればhot reloadします。
+
+## RomaKana
+
+`RomaKana` はローマ字とかなの双方向変換を担当します。
+
+- `roma2hiragana(_:)`
+- `roma2katakana(_:)`
+- `hiragana2roma(_:)`
+- `katakana2roma(_:)`
+
+`rklist` を読み、ローマ字→かな、かな→ローマ字の辞書を構築します。ローマ字→かなは長いキーからgreedy matchします。
+
+特殊処理:
+
+- `n` + 子音 → `ん`
+- 末尾 `n` → `ん`
+- 二重子音 → `っ`
+- `?`, `!` などの全角記号変換
+
+## 辞書関連の注意点
+
+- `study()` は必ず即時保存する。終了時保存だけに依存しない
+- staticな `studyDict` を使い、複数controller間の上書きを防ぐ
+- `CandidateSource` の先着勝ちは候補削除機能に影響する
+- local辞書は外部編集されるため、mtime hot reload が必要
+- Google変換のsuffix検出は `WordSearch.search()` で空候補を返し、実APIは `GyaimController` が起動する

--- a/docs/internal/dictionary-system.md
+++ b/docs/internal/dictionary-system.md
@@ -1,26 +1,20 @@
 # 辞書・学習システム
 
-## 中心ファイル
+このドキュメントでは、`WordSearch.swift` / `ConnectionDict.swift` / `StudyEntry.swift` を実装寄りに読みます。SwiftyGyaim の変換は、巨大な変換エンジンというより、ローマ字readingに対する複数辞書の検索と並び替えで構成されています。
 
-- `WordSearch.swift`
-- `ConnectionDict.swift`
-- `StudyEntry.swift`
-- `RomaKana.swift`
-- `DictEditorWindow.swift`
+## 1. 候補のデータ構造
 
-SwiftyGyaim の変換候補は、主に3層の辞書から作られます。
-
-## 3層辞書
-
-| 優先度 | 辞書 | 実装 | 保存先 | 特徴 |
-|---|---|---|---|---|
-| 1 | Study辞書 | `WordSearch.studyDict` | `~/.gyaim/studydict.txt` | 確定履歴による学習 |
-| 2 | Local辞書 | `WordSearch.localDict` | `~/.gyaim/localdict.txt` | ユーザー登録語 |
-| 3 | Connection辞書 | `ConnectionDict` | `Resources/dict.txt` | 固定辞書・連接対応 |
-
-候補は `SearchCandidate` として表現されます。
+候補は `SearchCandidate` です。
 
 ```swift
+enum CandidateSource: Equatable {
+    case study
+    case local
+    case connection
+    case external
+    case synthetic
+}
+
 struct SearchCandidate: Equatable {
     let word: String
     let reading: String?
@@ -28,49 +22,123 @@ struct SearchCandidate: Equatable {
 }
 ```
 
-`source` は候補削除可否やUI判断に使われます。
+`word` は表示・確定する文字列、`reading` は学習や削除に使う読み、`source` は候補の出自です。
 
-## SearchCandidate.source
+`source` は単なるメタ情報ではありません。候補削除では `.study` と `.local` だけ削除可能です。そのため検索時のdedup順序によって `source` が変わると、UI上の削除可否も変わります。
 
-| source | 意味 | 削除可否 |
-|---|---|---|
-| `.study` | 学習辞書由来 | 可 |
-| `.local` | ユーザー辞書由来 | 可 |
-| `.connection` | 固定連接辞書由来 | 不可 |
-| `.external` | クリップボード/選択テキスト等 | 不可 |
-| `.synthetic` | 入力文字列、かなfallback、タイムスタンプ等 | 不可 |
+## 2. `WordSearch` の持つ辞書
 
-## `WordSearch.search()`
+```swift
+private let connectionDict: ConnectionDict
+private let localDictFile: String
+private var localDict: [[String]]
+private var localDictTime: Date
 
-入口は次です。
+private(set) static var studyDict: [StudyEntry] = []
+private(set) static var studyDictFile: String = ""
+```
+
+local辞書はインスタンス変数、study辞書はstaticです。
+
+### なぜ studyDict は static か
+
+InputMethodKit はクライアントアプリごとに `GyaimController` を作ることがあります。つまり `WordSearch` も複数個作られます。
+
+study辞書がインスタンス変数だと次の事故が起きます。
+
+```text
+Aインスタンスが「乖離」を学習して保存
+Bインスタンスは古いstudyDictしか知らない
+Bインスタンスが別語を学習して保存
+→ Bの古い配列でファイルを上書きし「乖離」が消える
+```
+
+そのため、プロセス内では `WordSearch.studyDict` を唯一の真実にしています。
+
+## 3. 初期化
+
+```swift
+init(connectionDictFile: String, localDictFile: String, studyDictFile: String) {
+    self.localDictFile = localDictFile
+    self.connectionDict = ConnectionDict(dictFile: connectionDictFile)
+    self.localDict = Self.loadDict(dictFile: localDictFile)
+    self.localDictTime = Self.fileModTime(localDictFile)
+
+    if Self.studyDictFile != studyDictFile {
+        Self.studyDictFile = studyDictFile
+        Self.studyDict = Self.loadStudyDict(dictFile: studyDictFile)
+    }
+}
+```
+
+connection辞書は固定辞書なので毎回 `ConnectionDict` を作ります。study辞書はファイルパスが変わった場合だけ読み直します。テストでは一時ファイルを使うため、この「パスが変わったらreload」という条件が必要です。
+
+## 4. `search(query:searchMode:limit:)`
+
+入口です。
 
 ```swift
 func search(query: String, searchMode: Int, limit: Int = 0) -> [SearchCandidate]
 ```
 
-`searchMode`:
+最初にlocal辞書のmtimeを見ます。
 
-| 値 | 意味 |
-|---|---|
-| `0` | 前方一致。インクリメンタル候補 |
-| `1` | 完全一致。Space等で明示的に変換 |
-| `2` | Google結果表示。辞書検索自体はcontroller側で扱う |
+```swift
+let currentMtime = Self.fileModTime(localDictFile)
+if currentMtime > localDictTime {
+    localDict = Self.loadDict(dictFile: localDictFile)
+    localDictTime = currentMtime
+}
+```
 
-処理順:
+`DictEditorWindow` や外部エディタで `localdict.txt` が更新された場合、次回検索で自動反映されます。
 
-1. 空クエリなら空配列
-2. local辞書のmtimeを確認し、更新されていれば再読込
-3. 特殊入力を処理
-   - Googleトリガーsuffix
-   - `#`, `!`
-   - `ds` タイムスタンプ
-   - 大文字含み入力
-4. Study / Local / Connection を検索
-5. 重複候補を `word` 単位で除外
+## 5. 特殊query
 
-## 完全一致reading優先
+通常辞書検索の前に特殊入力を処理します。
 
-設定 `exactReadingMatchPriority` がONかつ `searchMode == 0` の場合、前方一致候補の並びを4バケットに分けます。
+```swift
+if GoogleTransliterate.hasTriggerSuffix(q) {
+    return candidates
+}
+
+if q == "ds" {
+    candidates.append(SearchCandidate(word: formatter.string(from: Date())))
+    return candidates
+}
+
+if q.range(of: "[A-Z]", options: .regularExpression) != nil {
+    candidates.append(SearchCandidate(word: q, reading: q))
+    return candidates
+}
+```
+
+Google suffix はここでは空候補を返すだけです。実際のAPI呼び出しは `GyaimController.searchAndShowCands()` がsuffixを見て `triggerGoogleTransliterate()` を呼びます。
+
+`ds` は日時候補、大文字含みはpass-through候補です。
+
+## 6. prefix / exact の正規表現
+
+```swift
+let escaped = NSRegularExpression.escapedPattern(for: q)
+let pattern = searchMode > 0 ? "^\(escaped)$" : "^\(escaped)"
+let regex = try? NSRegularExpression(pattern: pattern)
+```
+
+- prefix mode: `^q`
+- exact mode: `^q$`
+
+辞書のreadingに対してこの正規表現を当てます。読みはローマ字なので、正規表現もローマ字文字列に対して動きます。
+
+## 7. exactReadingMatchPriority の4バケット
+
+設定がONの場合、prefix検索でも完全一致readingを優先します。
+
+```swift
+let exactPriority = searchMode == 0 && Self.isExactReadingMatchPriority
+```
+
+ON時の順序:
 
 ```text
 1. studyDict exact
@@ -80,124 +148,150 @@ func search(query: String, searchMode: Int, limit: Int = 0) -> [SearchCandidate]
 5. connectionDict
 ```
 
-これは、短い読みの完全一致候補が長いprefix候補に埋もれる問題を避けるためです。
+実装上は `candfound: Set<String>` で `word` 単位のdedupをします。
 
-Connection辞書は最後に単一パスで検索します。固定辞書の単漢字exactを先に出すと、学習済みprefix候補を押し流すためです。
-
-## ConnectionDict
-
-`ConnectionDict` は `Resources/dict.txt` を読み込む固定辞書です。
-
-形式:
-
-```text
-romaji<TAB>surface<TAB>input_connection<TAB>output_connection
+```swift
+if entry.reading == q, !candfound.contains(entry.word) {
+    candidates.append(SearchCandidate(word: entry.word, reading: entry.reading, source: .study))
+    candfound.insert(entry.word)
+}
 ```
 
-内部では以下のリンクを作ります。
+ここで先に入った候補の `source` が残ります。同じ表記がstudyとconnectionの両方にある場合、studyが先なら `.study` として残り、候補削除可能になります。
 
-| リンク | 用途 |
-|---|---|
-| `keyLink` | 読みの先頭文字から候補リストへ辿る |
-| `connectionLink` | `inConnection` 値から連接可能候補へ辿る |
+## 8. OFF時の従来順序
 
-検索は `generateCand()` の再帰で行われます。
+OFF時は辞書ごとに単純に走査します。
 
 ```text
-pat が entry.pat と一致
-  → 候補を返す
-
-entry.pat が pat から始まる
-  → searchMode=0 ならprefix候補として返す
-
-pat が entry.pat から始まる
-  → 残りpatを outConnection で再帰検索
+study prefix
+local prefix
+connection
 ```
 
-これにより、単語を連結した複合候補を生成できます。
+MRU的な「最近学習したものが上に来る」挙動を保つためです。
 
-## Study辞書
+## 9. ConnectionDict の実装
 
-`StudyEntry` は以下を持ちます。
+`ConnectionDict` は固定辞書 `dict.txt` を読みます。
 
-| フィールド | 意味 |
-|---|---|
-| `reading` | ローマ字読み |
-| `word` | 確定語 |
-| `lastAccessTime` | 最終使用時刻 |
-| `frequency` | 使用回数 |
+```swift
+struct DictEntry {
+    let pat: String
+    let word: String
+    let inConnection: Int
+    let outConnection: Int
+    var keyLink: Int?
+    var connectionLink: Int?
+}
+```
 
-保存形式:
+### link構造
+
+全件を毎回線形走査すると重いので、2種類のリンクを作ります。
+
+```swift
+private var keyLink: [Int: Int] = [:]
+private var connectionLink: [Int: Int] = [:]
+```
+
+- `keyLink`: `pat` の先頭文字Unicode scalar → 最初の辞書index
+- `connectionLink`: `inConnection` → 最初の辞書index
+
+各 `DictEntry` の `keyLink` / `connectionLink` は同じキーの次entryへの linked list です。配列indexでリンクリストを作る実装です。
+
+### 再帰検索
+
+```swift
+private func generateCand(connection: Int?, pat: String,
+                          foundWord: String, foundPat: String,
+                          searchMode: Int,
+                          callback: (...))
+```
+
+3つのケースがあります。
+
+```swift
+if pat == entry.pat {
+    callback(foundWord + entry.word, foundPat + entry.pat, entry.outConnection)
+} else if entry.pat.hasPrefix(pat) {
+    if searchMode == 0 { callback(...) }
+} else if pat.hasPrefix(entry.pat) {
+    let restPat = String(pat.dropFirst(entry.pat.count))
+    generateCand(connection: entry.outConnection, pat: restPat, ...)
+}
+```
+
+例えば `pat` が複合語の先頭entryに一致したら、残りの `pat` を `outConnection` から再帰検索します。これにより、単語をつなげた候補を生成します。
+
+## 10. study()
+
+学習は `WordSearch.study(word:reading:)` が担当します。
+
+処理は以下です。
 
 ```text
-reading<TAB>word<TAB>timestamp<TAB>frequency
+平仮名学習設定を確認
+  ↓
+既存entry検索
+  ├─ あれば frequency++ / lastAccessTime更新 / 先頭へ移動
+  └─ なければ新規entryを先頭へ追加
+  ↓
+evict
+  ↓
+saveStudyDict
 ```
 
-旧2カラム形式も読み込み可能です。
+保存が即時なのが重要です。IMEは `deactivateServer` を経由せず終了することがあるため、終了時保存だけでは学習が失われます。
 
-## `WordSearch.study()`
+## 11. StudyEntry.score()
 
-通常確定時に呼ばれます。
+```swift
+func score() -> Double {
+    let frequencyBonus = log2(Double(max(frequency, 1))) * 3600.0
+    let charPenalty = Double(word.count) * 600.0
+    return lastAccessTime + frequencyBonus - charPenalty
+}
+```
 
-主な処理:
+スコアは「最近使った」「頻度が高い」「短い」語を残しやすくします。
 
-1. 平仮名学習設定を確認
-2. 既存entryなら頻度・時刻更新し先頭へ移動
-3. 新規entryなら先頭に追加
-4. 上限超過時にevict
-5. 即時ファイル保存
-6. 必要に応じてlocal辞書へ昇格
+- 頻度2倍で約1時間ぶんのボーナス
+- 1文字長いと約10分ぶんのペナルティ
+- ただし支配的なのは `lastAccessTime`
 
-`studyDict` は static です。InputMethodKit がクライアントごとに `GyaimController` / `WordSearch` を作るため、インスタンス変数にすると別インスタンスの保存で学習データが消えるからです。
+## 12. local辞書登録と削除
 
-## EvictionMode
-
-`StudyEntry.score()` は Mozc風の簡易スコアです。
+外部候補確定時などに `register(word:reading:)` が呼ばれます。
 
 ```text
-score = lastAccessTime + log2(frequency) * 3600 - word.count * 600
+localDict に [reading, word] を追加
+saveDict()
+localDictTime 更新
 ```
 
-| モード | 内容 |
-|---|---|
-| `.mru` | 最近使った順。末尾を削る |
-| `.none` | 淘汰なし。ただし実装上の上限処理は残る |
-| `.scoreBased` | 先頭一定件数を保護し、スコア最低のものを削る |
+削除は `deleteFromLocal` / `deleteFromStudy` です。どちらも削除後に即保存します。
 
-## Local辞書
+## 13. ファイル形式
 
-`~/.gyaim/localdict.txt` に保存されます。
-
-形式:
+### localdict.txt
 
 ```text
 reading<TAB>word
 ```
 
-`DictEditorWindow` で編集できます。`WordSearch.search()` は検索前にmtimeを見て、ファイルが更新されていればhot reloadします。
+### studydict.txt
 
-## RomaKana
+```text
+reading<TAB>word<TAB>timestamp<TAB>frequency
+```
 
-`RomaKana` はローマ字とかなの双方向変換を担当します。
+旧形式の2カラムstudy辞書も読み込めます。互換性を保ちながら、保存時には4カラム形式へ寄せます。
 
-- `roma2hiragana(_:)`
-- `roma2katakana(_:)`
-- `hiragana2roma(_:)`
-- `katakana2roma(_:)`
+## 14. 実装を読む時の注意
 
-`rklist` を読み、ローマ字→かな、かな→ローマ字の辞書を構築します。ローマ字→かなは長いキーからgreedy matchします。
-
-特殊処理:
-
-- `n` + 子音 → `ん`
-- 末尾 `n` → `ん`
-- 二重子音 → `っ`
-- `?`, `!` などの全角記号変換
-
-## 辞書関連の注意点
-
-- `study()` は必ず即時保存する。終了時保存だけに依存しない
-- staticな `studyDict` を使い、複数controller間の上書きを防ぐ
-- `CandidateSource` の先着勝ちは候補削除機能に影響する
-- local辞書は外部編集されるため、mtime hot reload が必要
-- Google変換のsuffix検出は `WordSearch.search()` で空候補を返し、実APIは `GyaimController` が起動する
+- `candfound` のdedup順序は候補順位だけでなく `CandidateSource` に影響する
+- `studyDict` はstaticなのでテストでは `resetStudyDict()` が必要
+- local辞書はインスタンス変数なので、hot reloadで外部変更を吸収する
+- `searchMode=2` は辞書検索というよりcontroller側の表示状態
+- `ConnectionDict` は配列indexリンクなので、`dict` の並び自体も検索順に影響する

--- a/docs/internal/feature-guide.md
+++ b/docs/internal/feature-guide.md
@@ -1,0 +1,253 @@
+# 機能別実装ガイド
+
+このファイルは「この機能はどこを読めばよいか」を起点にした実装ガイドです。
+
+## 1. 通常の日本語変換
+
+読むファイル:
+
+- `GyaimController.swift`
+- `WordSearch.swift`
+- `ConnectionDict.swift`
+- `RomaKana.swift`
+- `CandidateWindow.swift`
+
+流れ:
+
+```text
+キー入力
+  → inputPat更新
+  → WordSearch.search()
+  → candidates更新
+  → CandidateWindow表示
+  → Enter/数字キーでfix()
+  → WordSearch.study()
+```
+
+`inputPat` はローマ字のまま保持し、表示用に `RomaKana.roma2hiragana()` を使います。辞書検索も基本的にはローマ字readingに対して行います。
+
+## 2. ひらがな・カタカナ確定
+
+読むファイル:
+
+- `GyaimController.swift`
+- `RomaKana.swift`
+- `KeyBindings.swift`
+- `PreferencesWindow.swift`
+
+トリガー:
+
+| 操作 | デフォルト |
+|---|---|
+| ひらがな確定 | F6, Ctrl+Shift+U, `;` |
+| カタカナ確定 | F7, Ctrl+Shift+I, `q` |
+
+`KeyBindings` がショートカットを管理し、`GyaimController.handle()` が変換中に判定します。
+
+```text
+matchesHiragana / matchesKatakana
+  → fixAsKana(hiragana: ...)
+  → RomaKanaで変換
+  → insertText
+  → study
+```
+
+## 3. Google変換
+
+読むファイル:
+
+- `GoogleTransliterate.swift`
+- `GyaimController.swift`
+- `PreferencesWindow.swift`
+- `KeyBindings.swift`
+
+トリガー:
+
+- 入力末尾のsuffix。デフォルトは `` ` ``
+- 設定画面で登録したショートカット
+
+処理:
+
+1. `GoogleTransliterate.hasTriggerSuffix()` で検出
+2. `GyaimController.triggerGoogleTransliterate()`
+3. `GoogleTransliterate.searchCands()` が `https://inputtools.google.com/request` を呼ぶ
+4. APIが複数segmentを返したら `combineSegments()` で直積結合
+5. ひらがな/カタカナ重複を `filterCandidates()` で除外
+6. `SearchCandidate` 化し、`searchMode=2` で表示
+
+stale guard:
+
+```text
+pendingGoogleQuery = originalQuery
+callback時に pendingGoogleQuery == originalQuery を確認
+```
+
+これにより、遅れて返った古いAPI結果を表示しません。
+
+## 4. クリップボード候補
+
+読むファイル:
+
+- `GyaimController.swift`
+- `CopyText.swift`
+- `AppDelegate.swift`
+- `PreferencesWindow.swift`
+
+`CopyText` は `~/.gyaim/copytext` に文字列を保存します。
+
+更新経路は2つあります。
+
+1. `AppDelegate` の60秒timer
+2. `GyaimController.ClipboardMonitor` の0.5秒polling
+
+候補として表示するかどうかは設定で制御されます。
+
+`ClipboardMonitor` は `NSPasteboard.changeCount` を監視し、コピーが発生した時刻を記録します。候補表示時には「新しいコピーか」「すでに消費済みでないか」を見ます。
+
+## 5. 選択テキスト候補
+
+読むファイル:
+
+- `GyaimController.swift`
+- `PreferencesWindow.swift`
+
+入力開始時に `IMKTextInput.selectedRange()` と `attributedSubstring(from:)` で選択テキストを取得し、候補に追加します。
+
+注意点:
+
+- アプリによって `selectedRange()` が不正値を返す
+- 取得できない場合も正常系として扱う
+- 候補sourceは `.external`
+
+## 6. 候補削除
+
+読むファイル:
+
+- `GyaimController.swift`
+- `WordSearch.swift`
+- `KeyBindings.swift`
+- `PreferencesWindow.swift`
+
+トリガー:
+
+- modifier shortcut
+- 単キー `X`（Shift+X）
+
+処理:
+
+```text
+deleteCurrentCandidate()
+  ├─ candidate.source確認
+  ├─ .study → WordSearch.deleteFromStudy()
+  ├─ .local → WordSearch.deleteFromLocal()
+  └─ 再検索して候補表示更新
+```
+
+`CandidateSource` が正しく維持されていないと、削除可能候補が削除不可になったり、固定辞書候補を削除しようとしたりします。
+
+## 7. 学習辞書
+
+読むファイル:
+
+- `WordSearch.swift`
+- `StudyEntry.swift`
+- `PreferencesWindow.swift`
+
+通常確定時に `study(reading:word:)` が呼ばれます。
+
+学習しないケース:
+
+- IME切替時の自動確定 (`skipStudy: true`)
+- 平仮名学習OFFで、確定語が全ひらがな
+
+保存は即時です。`finish()` や終了時保存だけには依存しません。
+
+## 8. ユーザー辞書編集
+
+読むファイル:
+
+- `DictEditorWindow.swift`
+- `WordSearch.swift`
+
+`DictEditorWindow` で `~/.gyaim/localdict.txt` を編集します。
+
+`WordSearch.search()` は検索前にmtimeをチェックするため、ファイル保存後は次回検索で自動反映されます。
+
+## 9. ログ
+
+読むファイル:
+
+- `GyaimLogger.swift`
+- `PreferencesWindow.swift`
+
+カテゴリ:
+
+| カテゴリ | 内容 |
+|---|---|
+| `input` | キー入力・確定・状態遷移 |
+| `dict` | 辞書・Google変換・学習 |
+| `conversion` | ローマ字かな変換 |
+| `ui` | 候補ウィンドウ・設定画面 |
+| `config` | 設定・ファイルI/O |
+
+ファイルログ:
+
+```text
+~/.gyaim/gyaim.log
+```
+
+デフォルトでは無効で、設定画面から有効化します。
+
+## 10. 設定画面
+
+読むファイル:
+
+- `PreferencesWindow.swift`
+- `KeyBindings.swift`
+- `GoogleTransliterate.swift`
+- `WordSearch.swift`
+- `StudyEntry.swift`
+- `GyaimLogger.swift`
+
+設定値は多くが `UserDefaults` に保存されます。
+
+代表キー:
+
+| キー | 内容 |
+|---|---|
+| `GyaimKeyBindings` | ショートカット設定JSON |
+| `candidateDisplayMode` | 候補表示モード |
+| `googleTransliterateTrigger` | Google変換suffix |
+| `studyDictEvictionMode` | 学習辞書淘汰方式 |
+| `studyHiraganaEnabled` | 平仮名学習ON/OFF |
+| `exactReadingMatchPriority` | 完全一致reading優先 |
+| `loggingEnabled` | ログON/OFF |
+
+## 11. 画像・特殊入力
+
+読むファイル:
+
+- `WordSearch.swift`
+- `ImageManager.swift`
+- `Emulation.swift`
+
+`WordSearch.search()` には特殊入力の入口があります。
+
+| 入力 | 意味 |
+|---|---|
+| `ds` | 現在日時候補 |
+| 大文字含み | そのままpass through候補 |
+| `#` suffix | 色/画像系の入口 |
+| `!` suffix | 画像検索系の入口 |
+
+一部は現在placeholderに近く、実際の表示やキーエミュレーションは `ImageManager` / `Emulation` 側を読む必要があります。
+
+## 機能追加時のチェックリスト
+
+1. `GyaimController` の状態遷移に影響するか
+2. 候補sourceは正しいか
+3. 学習すべき確定か、skipすべき確定か
+4. 設定値を `UserDefaults` に持つならPreferencesWindowとテストを更新したか
+5. 候補ウィンドウ表示位置やフォーカスに影響しないか
+6. 対応する `docs/specs/` と `docs/adr/` が必要か
+7. ユニットテストまたはE2Eテストを追加できるか

--- a/docs/internal/ime-api.md
+++ b/docs/internal/ime-api.md
@@ -1,0 +1,130 @@
+# Swift / InputMethodKit で作る IME の概要
+
+## InputMethodKit の基本構造
+
+macOS の IME は InputMethodKit を使って実装できます。SwiftyGyaim では以下のクラス/APIが中心です。
+
+| API | SwiftyGyaimでの使い方 |
+|---|---|
+| `IMKServer` | `main.swift` で1つ作成し、IMEサーバとして起動 |
+| `IMKInputController` | `GyaimController` が継承。キーイベント・ライフサイクルを処理 |
+| `IMKTextInput` | 入力先アプリへの marked text / committed text の反映に使う |
+| `NSEvent` | `handle(_:client:)` に渡されるキーイベント |
+| `NSPanel` | 候補ウィンドウを非アクティブに表示 |
+
+## 起動
+
+`main.swift` は非常に小さく、`IMKServer` を作って `NSApplication` を実行します。
+
+```swift
+let server = IMKServer(name: "Gyaim_Connection",
+                       bundleIdentifier: Bundle.main.bundleIdentifier!)
+
+let delegate = AppDelegate()
+NSApplication.shared.delegate = delegate
+NSApplication.shared.run()
+```
+
+`name` は `Resources/Info.plist` の `InputMethodConnectionName` と対応します。ここがずれると macOS 側から IME サーバに接続できません。
+
+## Info.plist の役割
+
+IMEとして認識されるには、通常アプリとは異なるキーが必要です。
+
+代表例:
+
+| キー | 意味 |
+|---|---|
+| `InputMethodConnectionName` | `IMKServer` の connection name |
+| `InputMethodServerControllerClass` | `IMKInputController` サブクラス名 |
+| `InputMethodServerDelegateClass` | delegate class名 |
+| `LSBackgroundOnly` | バックグラウンドアプリとして動作 |
+| `ComponentInputModeDict` | 入力ソースとしての定義 |
+
+SwiftyGyaim のアプリ識別子は `com.pitecan.inputmethod.SwiftyGyaim` です。
+
+## IMKInputController のライフサイクル
+
+`GyaimController` は `IMKInputController` を継承します。
+
+主な override:
+
+| メソッド | 呼ばれるタイミング | 実装内容 |
+|---|---|---|
+| `init(server:delegate:client:)` | controller生成時 | 候補ウィンドウ、辞書、状態初期化 |
+| `activateServer(_:)` | IMEが有効化された時 | 辞書start、クリップボード取得、候補表示更新 |
+| `deactivateServer(_:)` | IMEが無効化された時 | 未確定テキストを確定、辞書finish |
+| `handle(_:client:)` | キー入力時 | 入力処理の中心 |
+| `menu()` | 入力メニュー表示時 | 設定・辞書エディタメニューを返す |
+| `showPreferences(_:)` | 設定表示 | `PreferencesWindow.show()` |
+
+## 入力先アプリとのやり取り
+
+入力先アプリは `IMKTextInput` として渡されます。SwiftyGyaim では主に以下を使います。
+
+| メソッド | 用途 |
+|---|---|
+| `setMarkedText(_:selectionRange:replacementRange:)` | 未確定テキストを表示 |
+| `insertText(_:replacementRange:)` | 確定テキストを挿入 |
+| `attributes(forCharacterIndex:lineHeightRectangle:)` | キャレット行矩形を取得し候補ウィンドウ位置に使う |
+| `selectedRange()` / `attributedSubstring(from:)` | 選択テキスト候補の取得に使う |
+
+### marked text と committed text
+
+IMEは通常、入力中の文字を「未確定テキスト」として表示し、Enterや候補選択で「確定テキスト」として挿入します。
+
+```text
+入力中:
+  setMarkedText("かな", ...)
+
+確定:
+  insertText("仮名", ...)
+```
+
+`insertText` を呼ぶと、多くのクライアントでは marked text は自動的に消えます。
+
+## クライアント取得の注意
+
+`deactivateServer(_:)` などライフサイクルメソッドでは `sender` が常に `IMKTextInput` とは限りません。そのため SwiftyGyaim では次のパターンを使います。
+
+```swift
+let resolvedClient = (sender as? IMKTextInput) ?? (self.client() as? IMKTextInput)
+```
+
+これは過去に「IME切替時に未確定テキストが消える」バグを防ぐための重要パターンです。
+
+## 候補ウィンドウ位置API
+
+候補ウィンドウは `IMKTextInput.attributes(forCharacterIndex:lineHeightRectangle:)` で得た `lineRect` を基準に表示します。
+
+```swift
+var lineRect = NSRect.zero
+client.attributes(forCharacterIndex: 0, lineHeightRectangle: &lineRect)
+```
+
+ただし一部のWebアプリはスクリーン座標ではなくローカル座標を返すことがあります。そのため現在は `CandidateWindowPositioner.resolveLineRect()` で妥当性を検証し、前回正常値やマウス位置へフォールバックします。
+
+## NSApplication activation policy
+
+SwiftyGyaim は `LSBackgroundOnly` なので通常は前面アプリになりません。
+
+- 候補ウィンドウ: `orderFront(nil)` のみ。アプリをアクティブ化しない
+- 設定画面/辞書エディタ: 一時的に `.accessory`
+- 閉じる時: `.prohibited`
+
+```swift
+NSApp.setActivationPolicy(.accessory)
+NSApp.activate(ignoringOtherApps: true)
+```
+
+## ターミナルの Ctrl+key 問題
+
+Terminal.app や iTerm2 は Ctrl+key を IME より先に処理する場合があります。そのため SwiftyGyaim では、Ctrl+Shift+U などの修飾キーショートカットに加えて、`;` や `q` の単キー確定も用意しています。
+
+## InputMethodKit 実装時の設計方針
+
+1. 入力先アプリのフォーカスを奪わない
+2. `sender` を過信せず `self.client()` でフォールバックする
+3. クライアントが返す座標・選択範囲は信用しすぎない
+4. ライフサイクルメソッドではテキスト消失を最優先で防ぐ
+5. 複数 `GyaimController` インスタンスを前提に共有状態を設計する

--- a/docs/internal/ime-api.md
+++ b/docs/internal/ime-api.md
@@ -1,130 +1,214 @@
 # Swift / InputMethodKit で作る IME の概要
 
-## InputMethodKit の基本構造
+このドキュメントでは、Swift/AppKit開発者向けに、macOS IME を作る時に出てくるAPIと、SwiftyGyaimでの具体的な使い方を説明します。
 
-macOS の IME は InputMethodKit を使って実装できます。SwiftyGyaim では以下のクラス/APIが中心です。
+## 1. 通常のmacOSアプリとの違い
 
-| API | SwiftyGyaimでの使い方 |
+IMEも `.app` ですが、ユーザーがDockから起動してウィンドウを操作するタイプのアプリではありません。入力ソースとしてmacOSに登録され、選択された時にキーイベントを受け取ります。
+
+SwiftyGyaimの `Info.plist` には、通常アプリに加えてIME用のキーが入っています。
+
+| キー | 役割 |
 |---|---|
-| `IMKServer` | `main.swift` で1つ作成し、IMEサーバとして起動 |
-| `IMKInputController` | `GyaimController` が継承。キーイベント・ライフサイクルを処理 |
-| `IMKTextInput` | 入力先アプリへの marked text / committed text の反映に使う |
-| `NSEvent` | `handle(_:client:)` に渡されるキーイベント |
-| `NSPanel` | 候補ウィンドウを非アクティブに表示 |
+| `InputMethodConnectionName` | `IMKServer` の名前 |
+| `InputMethodServerControllerClass` | `IMKInputController` サブクラス名 |
+| `InputMethodServerDelegateClass` | delegate class名 |
+| `ComponentInputModeDict` | 入力ソース定義 |
+| `LSBackgroundOnly` | バックグラウンドプロセスとして動作 |
 
-## 起動
+`LSBackgroundOnly` があるため、普通のCocoaアプリのように前面化するとフォーカス問題が起きます。
 
-`main.swift` は非常に小さく、`IMKServer` を作って `NSApplication` を実行します。
+## 2. `IMKServer`
+
+`main.swift` では `IMKServer` を作ります。
 
 ```swift
 let server = IMKServer(name: "Gyaim_Connection",
                        bundleIdentifier: Bundle.main.bundleIdentifier!)
-
-let delegate = AppDelegate()
-NSApplication.shared.delegate = delegate
-NSApplication.shared.run()
 ```
 
-`name` は `Resources/Info.plist` の `InputMethodConnectionName` と対応します。ここがずれると macOS 側から IME サーバに接続できません。
+この `name` は `Info.plist` の `InputMethodConnectionName` と一致している必要があります。
 
-## Info.plist の役割
+`IMKServer` は、macOSの入力メソッド機構とアプリプロセスを接続するサーバです。Swiftコードから直接メソッドを呼び続けるというより、作ってrun loopに入ると、InputMethodKitがcontrollerを生成してイベントを配送します。
 
-IMEとして認識されるには、通常アプリとは異なるキーが必要です。
+## 3. `IMKInputController`
 
-代表例:
+IMEの中核は `IMKInputController` のサブクラスです。
 
-| キー | 意味 |
-|---|---|
-| `InputMethodConnectionName` | `IMKServer` の connection name |
-| `InputMethodServerControllerClass` | `IMKInputController` サブクラス名 |
-| `InputMethodServerDelegateClass` | delegate class名 |
-| `LSBackgroundOnly` | バックグラウンドアプリとして動作 |
-| `ComponentInputModeDict` | 入力ソースとしての定義 |
-
-SwiftyGyaim のアプリ識別子は `com.pitecan.inputmethod.SwiftyGyaim` です。
-
-## IMKInputController のライフサイクル
-
-`GyaimController` は `IMKInputController` を継承します。
-
-主な override:
-
-| メソッド | 呼ばれるタイミング | 実装内容 |
-|---|---|---|
-| `init(server:delegate:client:)` | controller生成時 | 候補ウィンドウ、辞書、状態初期化 |
-| `activateServer(_:)` | IMEが有効化された時 | 辞書start、クリップボード取得、候補表示更新 |
-| `deactivateServer(_:)` | IMEが無効化された時 | 未確定テキストを確定、辞書finish |
-| `handle(_:client:)` | キー入力時 | 入力処理の中心 |
-| `menu()` | 入力メニュー表示時 | 設定・辞書エディタメニューを返す |
-| `showPreferences(_:)` | 設定表示 | `PreferencesWindow.show()` |
-
-## 入力先アプリとのやり取り
-
-入力先アプリは `IMKTextInput` として渡されます。SwiftyGyaim では主に以下を使います。
-
-| メソッド | 用途 |
-|---|---|
-| `setMarkedText(_:selectionRange:replacementRange:)` | 未確定テキストを表示 |
-| `insertText(_:replacementRange:)` | 確定テキストを挿入 |
-| `attributes(forCharacterIndex:lineHeightRectangle:)` | キャレット行矩形を取得し候補ウィンドウ位置に使う |
-| `selectedRange()` / `attributedSubstring(from:)` | 選択テキスト候補の取得に使う |
-
-### marked text と committed text
-
-IMEは通常、入力中の文字を「未確定テキスト」として表示し、Enterや候補選択で「確定テキスト」として挿入します。
-
-```text
-入力中:
-  setMarkedText("かな", ...)
-
-確定:
-  insertText("仮名", ...)
+```swift
+@objc(GyaimController)
+class GyaimController: IMKInputController {
+    override func handle(_ event: NSEvent!, client sender: Any!) -> Bool { ... }
+}
 ```
 
-`insertText` を呼ぶと、多くのクライアントでは marked text は自動的に消えます。
+`@objc(GyaimController)` は重要です。`Info.plist` からObjective-C runtime経由で参照されるため、Swiftのmodule名に依存しない名前を付けています。
 
-## クライアント取得の注意
+## 4. `init(server:delegate:client:)`
 
-`deactivateServer(_:)` などライフサイクルメソッドでは `sender` が常に `IMKTextInput` とは限りません。そのため SwiftyGyaim では次のパターンを使います。
+```swift
+override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
+    super.init(server: server, delegate: delegate, client: inputClient)
+    ...
+}
+```
+
+`client` は入力先アプリを表します。ただし型は `Any!` です。実際にテキスト操作する時は `IMKTextInput` にcastします。
+
+```swift
+if let client = inputClient as? (IMKTextInput & NSObjectProtocol) {
+    CopyText.set(NSPasteboard.general.string(forType: .string))
+}
+```
+
+SwiftyGyaimではこのinitで候補ウィンドウと辞書を初期化します。
+
+## 5. `activateServer` / `deactivateServer`
+
+```swift
+override func activateServer(_ sender: Any!) {
+    CopyText.set(NSPasteboard.general.string(forType: .string))
+    ws?.start()
+    showWindow()
+}
+```
+
+IMEが有効になった時に呼ばれます。辞書の開始処理やクリップボード更新を行います。
+
+```swift
+override func deactivateServer(_ sender: Any!) {
+    hideWindow()
+    fix(client: sender, skipStudy: true)
+    ws?.finish()
+}
+```
+
+IMEが無効になった時は、未確定テキストを確定します。これはMozc/Google日本語入力などと同じく、IME切替で入力が消えないようにするためです。
+
+`skipStudy: true` が重要です。IME切替による自動確定はユーザーが候補を選んだわけではないので、学習辞書には入れません。
+
+## 6. `handle(_:client:)`
+
+キー入力イベントの入口です。
+
+```swift
+override func handle(_ event: NSEvent!, client sender: Any!) -> Bool
+```
+
+- `event`: `NSEvent`。キーコード、文字、修飾キーを持つ
+- `sender`: 入力先クライアント。多くの場合 `IMKTextInput`
+- 戻り値: IMEが処理したら `true`
+
+SwiftyGyaimではASCII文字を中心に処理します。
+
+```swift
+guard let eventString = event.characters, !eventString.isEmpty else { return true }
+guard let c = eventString.utf8.first else { return true }
+```
+
+`NSEvent.keyCode` は物理キー、`event.characters` は修飾キーを反映した文字です。ショートカットの信頼性を上げるため、`KeyShortcut` は `keyCode` と `charCode` の両方を持ちます。
+
+## 7. `IMKTextInput`
+
+入力先アプリとのやり取りは `IMKTextInput` で行います。
+
+### 未確定テキスト
+
+```swift
+client.setMarkedText(attrStr,
+    selectionRange: NSRange(location: word.count, length: 0),
+    replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+```
+
+`setMarkedText` は、入力中の下線付きテキストを更新します。`selectionRange` はmarked text内のカーソル位置です。
+
+### 確定テキスト
+
+```swift
+client.insertText(word,
+    replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+```
+
+`insertText` で確定文字列を挿入します。通常、marked text はこれで消えます。
+
+### キャレット位置
+
+```swift
+var reportedLineRect = NSRect.zero
+client.attributes(forCharacterIndex: 0, lineHeightRectangle: &reportedLineRect)
+```
+
+候補ウィンドウ位置に使う矩形を取得します。ただし、これはクライアント実装依存です。WebView系ではスクリーン座標でない値が返ることがあるため、SwiftyGyaimでは妥当性検証を挟みます。
+
+### 選択テキスト
+
+```swift
+let range = client.selectedRange()
+if range.length > 0 {
+    let attrStr = client.attributedSubstring(from: range)
+}
+```
+
+選択テキスト候補のために使います。アプリによって `NSNotFound` や不正なrangeを返すことがあるので、防御的に扱います。
+
+## 8. `sender` を信用しすぎない
+
+InputMethodKit の罠として、`deactivateServer(_:)` などで渡ってくる `sender` が期待通りの `IMKTextInput` でないことがあります。
+
+そのため確定処理では必ずfallbackします。
 
 ```swift
 let resolvedClient = (sender as? IMKTextInput) ?? (self.client() as? IMKTextInput)
 ```
 
-これは過去に「IME切替時に未確定テキストが消える」バグを防ぐための重要パターンです。
+`self.client()` は `IMKInputController` が保持しているクライアントです。これを使わないと、IME切替時に未確定テキストが消えるバグになります。
 
-## 候補ウィンドウ位置API
+## 9. 候補ウィンドウで使う AppKit API
 
-候補ウィンドウは `IMKTextInput.attributes(forCharacterIndex:lineHeightRectangle:)` で得た `lineRect` を基準に表示します。
+候補ウィンドウは `NSPanel` です。
 
 ```swift
-var lineRect = NSRect.zero
-client.attributes(forCharacterIndex: 0, lineHeightRectangle: &lineRect)
+styleMask: [.borderless, .nonactivatingPanel]
 ```
 
-ただし一部のWebアプリはスクリーン座標ではなくローカル座標を返すことがあります。そのため現在は `CandidateWindowPositioner.resolveLineRect()` で妥当性を検証し、前回正常値やマウス位置へフォールバックします。
+`orderFront(nil)` で表示し、`NSApp.activate` はしません。
 
-## NSApplication activation policy
+```swift
+cw.setFrameOrigin(origin)
+cw.orderFront(nil)
+```
 
-SwiftyGyaim は `LSBackgroundOnly` なので通常は前面アプリになりません。
-
-- 候補ウィンドウ: `orderFront(nil)` のみ。アプリをアクティブ化しない
-- 設定画面/辞書エディタ: 一時的に `.accessory`
-- 閉じる時: `.prohibited`
+設定画面や辞書エディタは入力先からフォーカスを移してよいUIなので、一時的にactivation policyを変えます。
 
 ```swift
 NSApp.setActivationPolicy(.accessory)
 NSApp.activate(ignoringOtherApps: true)
 ```
 
-## ターミナルの Ctrl+key 問題
+閉じる時は `.prohibited` に戻します。
 
-Terminal.app や iTerm2 は Ctrl+key を IME より先に処理する場合があります。そのため SwiftyGyaim では、Ctrl+Shift+U などの修飾キーショートカットに加えて、`;` や `q` の単キー確定も用意しています。
+## 10. IME開発で起きやすい問題
 
-## InputMethodKit 実装時の設計方針
+### フォーカスを奪う
 
-1. 入力先アプリのフォーカスを奪わない
-2. `sender` を過信せず `self.client()` でフォールバックする
-3. クライアントが返す座標・選択範囲は信用しすぎない
-4. ライフサイクルメソッドではテキスト消失を最優先で防ぐ
-5. 複数 `GyaimController` インスタンスを前提に共有状態を設計する
+通常の `NSWindow` を表示したり `NSApp.unhide(nil)` を呼ぶと、入力先アプリがフォーカスを失うことがあります。候補ウィンドウでは絶対に避けます。
+
+### クライアント座標が信用できない
+
+`lineRect` や `selectedRange` はアプリ依存です。取得に成功しても意味が正しいとは限りません。
+
+### controllerが複数できる
+
+クライアントごとに `GyaimController` が生成され得ます。学習辞書のような共有状態はstaticや外部保存を含めて設計します。
+
+### ターミナルがCtrlキーを奪う
+
+Terminal.app/iTerm2では Ctrl+key がIMEに届かないことがあります。SwiftyGyaimでは `;` / `q` など単キー操作を併用しています。
+
+## 11. Swift実装としての特徴
+
+- InputMethodKitはObjective-C由来APIなので `Any!` やIUOが多い
+- `@objc` 名、Info.plist、runtime参照の整合が必要
+- `NSRange(location: NSNotFound, length: NSNotFound)` のようなCocoa慣習が残る
+- UIはAppKitでコード生成しており、SwiftUIは使っていない
+- 非同期Google変換は `URLSession` → main queue callback でUI更新する

--- a/docs/internal/input-flow.md
+++ b/docs/internal/input-flow.md
@@ -1,175 +1,338 @@
 # 入力・変換・確定フロー
 
-## 中心ファイル
+このファイルでは、`GyaimController.swift` の実装を中心に、キー入力1回がどのように状態を変え、候補検索・marked text・確定に進むかを追います。
 
-- `GyaimController.swift`
-- `RomaKana.swift`
-- `WordSearch.swift`
-- `CandidateWindow.swift`
-- `KeyBindings.swift`
+## 1. 状態は `GyaimController` に集約されている
 
-`GyaimController.handle(_:client:)` が全キー入力の入口です。
+`GyaimController` の入力状態は、ほぼ次の4変数で説明できます。
 
-## 状態モデル
+```swift
+private var inputPat = ""
+private var candidates: [SearchCandidate] = []
+private var nthCand = 0
+private var searchMode = 0
 
-```text
-未入力
-  │  通常文字入力
-  ▼
-変換中 inputPat != ""
-  │
-  ├─ 文字追加 / Backspace → 再検索
-  ├─ Space → 候補選択 or 完全一致検索へ遷移
-  ├─ Enter / 数字キー → 確定
-  ├─ Escape → キャンセル
-  ├─ F6 / ; → ひらがな確定
-  ├─ F7 / q → カタカナ確定
-  ├─ Googleトリガー → 非同期Google候補
-  └─ Shift+X等 → 候補削除
+private var converting: Bool {
+    !inputPat.isEmpty
+}
 ```
 
-## `handle(_:client:)` の処理順
+- `inputPat`: ユーザーが打ったローマ字列
+- `candidates`: 現在の候補全体
+- `nthCand`: `candidates` のうち marked text として出している候補
+- `searchMode`: `0=prefix`, `1=exact`, `2=Google`
 
-概略は次の通りです。
+ポイントは、未確定文字列を「かな」ではなく「ローマ字」で持つことです。`nihon` と打っている時、`inputPat` は `"nihon"` のままで、表示やfallbackのタイミングで `RomaKana` を使います。
 
-1. `keyDown` 以外は処理しない
-2. JISかな/英数キーは消費する
-3. 変換中ショートカットを先に判定
-   - ひらがな確定
-   - カタカナ確定
-   - Google変換
-   - 候補削除
-4. `event.characters` から1文字目を取得
-5. 単キー確定 `;` / `q` を判定
-6. Backspace / Escape / Space / Enter / 数字キー / 通常文字を処理
+## 2. `handle(_:client:)` の実装上の読み方
 
-ショートカットが先に判定されるのは、通常入力として `inputPat` に入る前にアクションとして扱うためです。
+`handle(_:client:)` は長いですが、上から順番に優先度の高いものを処理しているだけです。
 
-## 通常文字入力
-
-通常文字が来ると `inputPat` に追加し、`searchAndShowCands()` を呼びます。
-
-```text
-inputPat += typedCharacter
-searchAndShowCands(client: sender)
+```swift
+override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
+    guard event.type == .keyDown else { return false }
+    ...
+}
 ```
 
-`searchAndShowCands()` はおおむね以下を行います。
+戻り値は「IMEがこのイベントを消費したか」です。`true` なら入力先アプリには渡りません。
 
-1. `WordSearch.search(query: inputPat, searchMode: searchMode)`
-2. クリップボード候補・選択テキスト候補など外部候補を追加
-3. `showCands()` で候補ウィンドウを更新
-4. クライアントへ marked text を設定
+### 2.1 JISかな/英数キー
 
-## Space キー
-
-Space は状態により意味が変わります。
-
-| 状態 | 動作 |
-|---|---|
-| 未変換 | 通常スペースとしてアプリに渡す |
-| 候補あり | `nthCand` を進め、候補ページを更新 |
-| 候補なし/必要時 | `searchMode=1` の完全一致検索へ遷移 |
-
-候補ウィンドウのページングは `CandidateDisplayMode.current.maxVisible` を使います。
-
-## Enter / 数字キー確定
-
-`fix(client:)` が候補を確定します。
-
-- `nthCand` が候補範囲内ならその候補を確定
-- 通常確定では `WordSearch.study()` を呼ぶ
-- `insertText` で入力先へ挿入
-- 状態リセットと候補ウィンドウ非表示
-
-IME切替時の `deactivateServer` では `fix(client: sender, skipStudy: true)` を使います。ユーザーが明示的に選んでいないため学習しません。
-
-## ひらがな / カタカナ確定
-
-`fixAsKana(hiragana:client:)` で `inputPat` を `RomaKana` により変換します。
-
-| 操作 | 実装 | 例 |
-|---|---|---|
-| F6 / `;` | `roma2hiragana` | `nihon` → `にほん` |
-| F7 / `q` | `roma2katakana` | `nihon` → `ニホン` |
-
-通常確定なので学習対象になります。ただし平仮名学習の設定がOFFなら、全ひらがな語は `WordSearch.study()` でスキップされます。
-
-## Google変換
-
-Google変換は2種類のトリガーがあります。
-
-1. 入力末尾のサフィックス（デフォルト `` ` ``）
-2. 設定されたショートカット
-
-処理フロー:
-
-```text
-triggerGoogleTransliterate()
-  ├─ query を確定
-  ├─ pendingGoogleQuery = query
-  ├─ GoogleTransliterate.searchCands(query) 非同期実行
-  └─ callback
-      ├─ pendingGoogleQuery が一致しなければ破棄
-      ├─ Google候補 + かなfallback を SearchCandidate化
-      ├─ searchMode = 2
-      └─ showCands()
+```swift
+if keyCode == kVirtualJISKanaModeKey || keyCode == kVirtualJISRomanModeKey {
+    return true
+}
 ```
 
-`pendingGoogleQuery` は、API応答待ちの間に入力が変わった場合に古い結果を捨てる stale guard です。
+JISキーボードのかな/英数キーは、IME切替に絡むキーなのでここでは消費します。
 
-## Backspace / Escape
+### 2.2 変換中ショートカット
 
-Backspace:
-
-- 候補選択中なら `nthCand` を戻す
-- そうでなければ `inputPat` 末尾を削除
-- 空になれば状態リセット
-
-Escape:
-
-- `resetState()`
-- marked text を消す
-- 候補ウィンドウを隠す
-
-## 候補削除
-
-候補表示中に削除ショートカットを押すと `deleteCurrentCandidate(client:)` が呼ばれます。
-
-削除可能なのは `SearchCandidate.source` が以下のものです。
-
-- `.study`
-- `.local`
-
-削除不可:
-
-- `.connection`
-- `.external`
-- `.synthetic`
-
-削除後は再検索し、候補ウィンドウを更新します。
-
-## marked text 更新
-
-変換中はクライアントに未確定文字列を表示します。表示する文字列は基本的に `RomaKana.roma2hiragana(inputPat)` です。
-
-```text
-inputPat: "nihon"
-marked text: "にほん"
+```swift
+if converting, KeyBindings.shared.matchesHiragana(event: event) {
+    fixAsKana(hiragana: true, client: sender)
+    return true
+}
 ```
 
-候補選択中でも、入力先には未確定テキストがあり、候補ウィンドウで変換候補を選ぶ構成です。
+`converting` 中だけ有効です。通常入力より先に見ることで、例えば `Ctrl+G` を文字入力ではなくGoogle変換として扱えます。
 
-## routeEvent との関係
+判定される順番:
 
-過去の設計で、キー入力分岐の一部は副作用なしでテスト可能な `routeEvent` として抽出されています。`HandleEventTests` はこの分岐ロジックを広くカバーします。
+1. ひらがな確定
+2. カタカナ確定
+3. Google変換
+4. 候補削除
 
-ただし実際の `handle(_:client:)` は、ショートカット、クライアント操作、候補表示、辞書学習など副作用を伴うため、`routeEvent` と完全に同一ではありません。
+### 2.3 `event.characters` の取得
 
-## 重要な注意点
+```swift
+guard let eventString = event.characters, !eventString.isEmpty else { return true }
+guard let c = eventString.utf8.first else { return true }
+```
 
-- `deactivateServer` では必ず未確定文字列を確定する
-- deactivation確定では学習しない
-- `sender` が不正でも `self.client()` でフォールバックする
-- Google結果は非同期なので stale guard が必須
-- 候補削除は `CandidateSource` の整合性に依存する
+SwiftyGyaim の通常入力処理はASCII前提なので、分岐は `UInt8` の `c` で行います。日本語そのもののキー入力をここで受ける設計ではありません。
+
+## 3. 分岐ごとの副作用
+
+### Backspace / Escape
+
+```swift
+if c == 0x08 || c == 0x7f || c == 0x1b {
+    if !bsThrough, converting {
+        if nthCand > 0 {
+            nthCand -= 1
+            showCands(client: sender)
+        } else {
+            inputPat = String(inputPat.dropLast())
+            searchAndShowCands(client: sender)
+        }
+        handled = true
+    }
+}
+```
+
+候補選択中なら候補を戻し、そうでなければ `inputPat` の末尾を削ります。削った結果に対して再検索するため、Backspaceでも `searchAndShowCands()` が呼ばれます。
+
+`tmpImageDisplayed` / `bsThrough` は画像候補貼り付け時の特殊処理です。画像を一度仮貼りした後のBackspaceをIME側でどう扱うかを制御します。
+
+### Space
+
+```swift
+else if c == 0x20 {
+    if converting {
+        if nthCand < candidates.count - 1 {
+            nthCand += 1
+            showCands(client: sender)
+        }
+        handled = true
+    }
+}
+```
+
+Space は候補を進めます。`nthCand` を1つ進めて `showCands()` を呼ぶだけです。検索自体はしません。
+
+### Enter
+
+```swift
+else if c == 0x0a || c == 0x0d {
+    if converting {
+        if searchMode > 0 {
+            fix(client: sender)
+        } else {
+            if nthCand == 0 {
+                searchMode = 1
+                searchAndShowCands(client: sender)
+            } else {
+                fix(client: sender)
+            }
+        }
+        handled = true
+    }
+}
+```
+
+ここがGyaimらしい挙動です。
+
+- prefix mode (`searchMode == 0`) かつ `nthCand == 0` のEnterは、即確定ではなく exact search に遷移します
+- すでに候補を選んでいる、または exact/Google mode なら確定します
+
+つまり最初のEnterは「変換」、次のEnterは「確定」に近い振る舞いになります。
+
+### 数字キー
+
+```swift
+else if converting, nthCand > 0 || searchMode > 0,
+        c >= 0x31, c <= 0x39 {
+    let num = Int(c - 0x30)
+    let targetIndex = nthCand + num
+    if targetIndex < candidates.count {
+        nthCand = targetIndex
+        fix(client: sender)
+    }
+}
+```
+
+候補ウィンドウに見えている1〜9番の候補を選択します。`targetIndex = nthCand + num` なのは、候補ウィンドウが `nthCand + 1` 以降を表示しているためです。
+
+### 通常文字
+
+```swift
+else if c >= 0x21, c <= 0x7e,
+        modifierFlags.isDisjoint(with: [.control, .command, .option]) {
+    if nthCand > 0 || searchMode > 0 {
+        fix(client: sender)
+    }
+    if inputPat.isEmpty {
+        captureExternalCandidates(client: sender)
+    }
+    inputPat += eventString
+    searchAndShowCands(client: sender)
+    searchMode = 0
+    handled = true
+}
+```
+
+候補選択中に通常文字を打つと、まず現在候補を確定してから新しい入力を始めます。これは「変換中に次の単語を打ち始めたら前の単語を確定する」というIMEの自然な挙動です。
+
+入力開始時だけ `captureExternalCandidates()` を呼ぶ点も重要です。クリップボードや選択テキスト候補は、入力途中で毎回取り直すのではなく「最初のキー入力時点」の文脈として固定します。
+
+## 4. `searchAndShowCands()` の詳細
+
+```swift
+private func searchAndShowCands(client sender: Any?) {
+    guard let ws else { return }
+
+    if GoogleTransliterate.hasTriggerSuffix(inputPat) {
+        let query = GoogleTransliterate.stripTriggerSuffix(inputPat)
+        triggerGoogleTransliterate(query: query, client: sender)
+        return
+    }
+
+    if searchMode == 1 {
+        ... exact search ...
+    } else {
+        ... prefix search ...
+    }
+
+    nthCand = 0
+    showCands(client: sender)
+}
+```
+
+### Google suffix が最優先
+
+辞書検索より先に `GoogleTransliterate.hasTriggerSuffix()` を見ます。suffixが付いていたら通常検索はせず、非同期Google変換に移ります。
+
+### exact search
+
+```swift
+candidates = ws.search(query: inputPat, searchMode: searchMode)
+let katakana = rk.roma2katakana(inputPat)
+candidates.insert(SearchCandidate(word: katakana), at: 0)
+let hiragana = rk.roma2hiragana(inputPat)
+candidates.insert(SearchCandidate(word: hiragana), at: 0)
+```
+
+完全一致モードでは、辞書候補に加えてかな候補を先頭に置きます。`filter` で同じwordを除外してから `insert` するので、重複してもかな候補が前に来ます。
+
+### prefix search
+
+```swift
+let searchResults = ws.search(query: inputPat, searchMode: searchMode)
+let hiragana = rk.roma2hiragana(inputPat)
+candidates = Self.buildPrefixCandidates(...)
+```
+
+`buildPrefixCandidates()` はテスト可能なstatic関数に切り出されています。
+
+```swift
+candidates.insert(SearchCandidate(word: inputPat), at: 0)
+if candidates.count < CandidateDisplayMode.current.maxVisible, !hiragana.isEmpty {
+    candidates.append(SearchCandidate(word: hiragana))
+}
+```
+
+prefix中は `inputPat` 自体を第0候補にします。これにより、未変換のローマ字をそのまま確定する経路が残ります。
+
+## 5. `showCands()` の詳細
+
+`showCands()` は名前以上に重要で、入力先アプリへの marked text 更新もここで行います。
+
+```swift
+let words = candidates.map(\.word)
+guard nthCand < words.count, let word = words[safe: nthCand] else { return }
+guard let client = sender as? IMKTextInput else { return }
+```
+
+### marked text
+
+```swift
+let attrStr = NSAttributedString(string: word, attributes: attrs)
+client.setMarkedText(attrStr,
+    selectionRange: NSRange(location: word.count, length: 0),
+    replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+```
+
+ここで入力先アプリ上の未確定テキストが更新されます。候補選択で `nthCand` が変わるたびに、marked text も候補語に変わります。
+
+### 候補ウィンドウ
+
+```swift
+for i in 0..<maxCandList {
+    let idx = nthCand + 1 + i
+    guard idx < words.count else { break }
+    candList.append(words[idx])
+}
+```
+
+候補ウィンドウには「現在marked textに出ている候補の次」から渡します。なので `selectedIndex` は現在 `-1` です。
+
+## 6. 確定処理 `fix()`
+
+```swift
+private func fix(client sender: Any? = nil, skipStudy: Bool = false) {
+    guard nthCand < candidates.count else {
+        resetState()
+        return
+    }
+    let candidate = candidates[nthCand]
+    let word = candidate.word
+    let reading = candidate.reading ?? inputPat
+```
+
+`reading` は候補が持っていればそれを使い、なければ現在の `inputPat` を使います。外部候補やsynthetic候補では `reading == nil` があり得るためです。
+
+クライアント取得は必ずfallbackします。
+
+```swift
+let resolvedClient = (sender as? IMKTextInput) ?? (self.client() as? IMKTextInput)
+```
+
+`sender` だけに頼ると、deactivation時にテキストを失うことがあります。
+
+### 学習と登録
+
+```swift
+if skipStudy {
+    ...
+} else {
+    let isExternalCandidate = (word == clipboardCandidate || word == selectedCandidate)
+    if isExternalCandidate {
+        ws?.register(word: word, reading: inputPat)
+    } else if let reading = candidate.reading {
+        ws?.study(word: word, reading: reading)
+    } else {
+        ws?.study(word: word, reading: inputPat)
+    }
+}
+```
+
+外部候補は学習辞書ではなくlocal辞書へ登録します。通常候補はstudy辞書に入ります。`ds` はタイムスタンプなので学習しません。
+
+## 7. `routeEvent()` は何のためにあるか
+
+`routeEvent()` は `handle()` の分岐ロジックをテストするための純粋関数です。
+
+```swift
+static func routeEvent(...) -> HandleResult
+```
+
+戻り値は副作用ではなく `HandleAction` です。
+
+```swift
+enum HandleAction: Equatable {
+    case searchAndShow
+    case showCands
+    case fix
+    case fixAsKana(hiragana: Bool)
+    case googleTransliterate
+    case deleteCandidate
+    ...
+}
+```
+
+`handle()` は実際に `setMarkedText` や `insertText` を呼ぶため、テストが難しくなります。そこで分岐条件だけを `routeEvent()` に寄せ、`HandleEventTests` で網羅しています。
+
+ただし、`handle()` と `routeEvent()` は完全に同じ実装ではありません。`routeEvent()` は「分岐の契約」をテストするためのモデルです。副作用や実際のUI更新は `handle()` 側を読む必要があります。

--- a/docs/internal/input-flow.md
+++ b/docs/internal/input-flow.md
@@ -1,0 +1,175 @@
+# 入力・変換・確定フロー
+
+## 中心ファイル
+
+- `GyaimController.swift`
+- `RomaKana.swift`
+- `WordSearch.swift`
+- `CandidateWindow.swift`
+- `KeyBindings.swift`
+
+`GyaimController.handle(_:client:)` が全キー入力の入口です。
+
+## 状態モデル
+
+```text
+未入力
+  │  通常文字入力
+  ▼
+変換中 inputPat != ""
+  │
+  ├─ 文字追加 / Backspace → 再検索
+  ├─ Space → 候補選択 or 完全一致検索へ遷移
+  ├─ Enter / 数字キー → 確定
+  ├─ Escape → キャンセル
+  ├─ F6 / ; → ひらがな確定
+  ├─ F7 / q → カタカナ確定
+  ├─ Googleトリガー → 非同期Google候補
+  └─ Shift+X等 → 候補削除
+```
+
+## `handle(_:client:)` の処理順
+
+概略は次の通りです。
+
+1. `keyDown` 以外は処理しない
+2. JISかな/英数キーは消費する
+3. 変換中ショートカットを先に判定
+   - ひらがな確定
+   - カタカナ確定
+   - Google変換
+   - 候補削除
+4. `event.characters` から1文字目を取得
+5. 単キー確定 `;` / `q` を判定
+6. Backspace / Escape / Space / Enter / 数字キー / 通常文字を処理
+
+ショートカットが先に判定されるのは、通常入力として `inputPat` に入る前にアクションとして扱うためです。
+
+## 通常文字入力
+
+通常文字が来ると `inputPat` に追加し、`searchAndShowCands()` を呼びます。
+
+```text
+inputPat += typedCharacter
+searchAndShowCands(client: sender)
+```
+
+`searchAndShowCands()` はおおむね以下を行います。
+
+1. `WordSearch.search(query: inputPat, searchMode: searchMode)`
+2. クリップボード候補・選択テキスト候補など外部候補を追加
+3. `showCands()` で候補ウィンドウを更新
+4. クライアントへ marked text を設定
+
+## Space キー
+
+Space は状態により意味が変わります。
+
+| 状態 | 動作 |
+|---|---|
+| 未変換 | 通常スペースとしてアプリに渡す |
+| 候補あり | `nthCand` を進め、候補ページを更新 |
+| 候補なし/必要時 | `searchMode=1` の完全一致検索へ遷移 |
+
+候補ウィンドウのページングは `CandidateDisplayMode.current.maxVisible` を使います。
+
+## Enter / 数字キー確定
+
+`fix(client:)` が候補を確定します。
+
+- `nthCand` が候補範囲内ならその候補を確定
+- 通常確定では `WordSearch.study()` を呼ぶ
+- `insertText` で入力先へ挿入
+- 状態リセットと候補ウィンドウ非表示
+
+IME切替時の `deactivateServer` では `fix(client: sender, skipStudy: true)` を使います。ユーザーが明示的に選んでいないため学習しません。
+
+## ひらがな / カタカナ確定
+
+`fixAsKana(hiragana:client:)` で `inputPat` を `RomaKana` により変換します。
+
+| 操作 | 実装 | 例 |
+|---|---|---|
+| F6 / `;` | `roma2hiragana` | `nihon` → `にほん` |
+| F7 / `q` | `roma2katakana` | `nihon` → `ニホン` |
+
+通常確定なので学習対象になります。ただし平仮名学習の設定がOFFなら、全ひらがな語は `WordSearch.study()` でスキップされます。
+
+## Google変換
+
+Google変換は2種類のトリガーがあります。
+
+1. 入力末尾のサフィックス（デフォルト `` ` ``）
+2. 設定されたショートカット
+
+処理フロー:
+
+```text
+triggerGoogleTransliterate()
+  ├─ query を確定
+  ├─ pendingGoogleQuery = query
+  ├─ GoogleTransliterate.searchCands(query) 非同期実行
+  └─ callback
+      ├─ pendingGoogleQuery が一致しなければ破棄
+      ├─ Google候補 + かなfallback を SearchCandidate化
+      ├─ searchMode = 2
+      └─ showCands()
+```
+
+`pendingGoogleQuery` は、API応答待ちの間に入力が変わった場合に古い結果を捨てる stale guard です。
+
+## Backspace / Escape
+
+Backspace:
+
+- 候補選択中なら `nthCand` を戻す
+- そうでなければ `inputPat` 末尾を削除
+- 空になれば状態リセット
+
+Escape:
+
+- `resetState()`
+- marked text を消す
+- 候補ウィンドウを隠す
+
+## 候補削除
+
+候補表示中に削除ショートカットを押すと `deleteCurrentCandidate(client:)` が呼ばれます。
+
+削除可能なのは `SearchCandidate.source` が以下のものです。
+
+- `.study`
+- `.local`
+
+削除不可:
+
+- `.connection`
+- `.external`
+- `.synthetic`
+
+削除後は再検索し、候補ウィンドウを更新します。
+
+## marked text 更新
+
+変換中はクライアントに未確定文字列を表示します。表示する文字列は基本的に `RomaKana.roma2hiragana(inputPat)` です。
+
+```text
+inputPat: "nihon"
+marked text: "にほん"
+```
+
+候補選択中でも、入力先には未確定テキストがあり、候補ウィンドウで変換候補を選ぶ構成です。
+
+## routeEvent との関係
+
+過去の設計で、キー入力分岐の一部は副作用なしでテスト可能な `routeEvent` として抽出されています。`HandleEventTests` はこの分岐ロジックを広くカバーします。
+
+ただし実際の `handle(_:client:)` は、ショートカット、クライアント操作、候補表示、辞書学習など副作用を伴うため、`routeEvent` と完全に同一ではありません。
+
+## 重要な注意点
+
+- `deactivateServer` では必ず未確定文字列を確定する
+- deactivation確定では学習しない
+- `sender` が不正でも `self.client()` でフォールバックする
+- Google結果は非同期なので stale guard が必須
+- 候補削除は `CandidateSource` の整合性に依存する

--- a/docs/internal/source-walkthrough.md
+++ b/docs/internal/source-walkthrough.md
@@ -1,0 +1,299 @@
+# ソースコードを読む: 実装ウォークスルー
+
+このドキュメントは、SwiftyGyaim の実装を「上から順に読む」ためのガイドです。Swift の文法や Cocoa/AppKit の基礎は知っている前提で、IME固有のAPIと、このリポジトリでの具体的な実装判断に踏み込みます。
+
+## 1. エントリポイント: `main.swift`
+
+SwiftyGyaim のプロセスは通常の Cocoa app と同じく `NSApplication` を回しますが、IMEとして重要なのは `IMKServer` を作る点です。
+
+```swift
+let server = IMKServer(name: "Gyaim_Connection",
+                       bundleIdentifier: Bundle.main.bundleIdentifier!)
+
+let delegate = AppDelegate()
+NSApplication.shared.delegate = delegate
+NSApplication.shared.run()
+```
+
+ここでの `server` 変数は使われていないように見えますが、生成して生存させること自体が目的です。`IMKServer` は `Resources/Info.plist` の `InputMethodConnectionName` と同じ名前で作られ、macOS の入力ソース機構から接続されます。
+
+ポイントは次の2つです。
+
+- `IMKServer(name:)` の `name` と `Info.plist` の接続名が一致していること
+- `NSApplication.shared.run()` に入る前に server を作っていること
+
+`server` をローカル変数にしているのは少し不安に見えますが、トップレベルコードなのでプロセス生存中に保持されます。
+
+## 2. アプリ起動後: `AppDelegate`
+
+`AppDelegate.applicationDidFinishLaunching` は、IMEとしての最小限の初期化を行います。
+
+```swift
+func applicationDidFinishLaunching(_ notification: Notification) {
+    Config.setup()
+    Log.config.info("Gyaim launched")
+
+    clipboardTimer = Timer.scheduledTimer(withTimeInterval: 60.0, repeats: true) { _ in
+        CopyText.set(NSPasteboard.general.string(forType: .string))
+    }
+}
+```
+
+`Config.setup()` は `~/.gyaim/` などのユーザーデータ置き場を整えます。クリップボードは後述の `ClipboardMonitor` でも監視しますが、ここではバックアップ的に60秒周期で `CopyText` に保存しています。
+
+終了時は次の処理です。
+
+```swift
+func applicationWillTerminate(_ notification: Notification) {
+    GyaimController.saveStudyDictIfNeeded()
+    FileLogger.shared.flush()
+    clipboardTimer?.invalidate()
+}
+```
+
+`WordSearch.study()` は現在、学習ごとに即時保存します。それでも `applicationWillTerminate` に保存処理を残しているのは、IMEプロセスのライフサイクルは通常アプリより読みにくく、終了時のセーフティネットを置く価値があるためです。
+
+## 3. IME本体: `GyaimController`
+
+`GyaimController` は `IMKInputController` のサブクラスです。macOSから見ると、このクラスが「入力メソッドのcontroller」です。
+
+```swift
+@objc(GyaimController)
+class GyaimController: IMKInputController {
+    private static var shared: GyaimController?
+
+    private var inputPat = ""
+    private var candidates: [SearchCandidate] = []
+    private var nthCand = 0
+    private var searchMode = 0
+    ...
+}
+```
+
+`@objc(GyaimController)` が重要です。`Info.plist` の `InputMethodServerControllerClass` から Objective-C runtime 経由で参照されるため、Swift側の型名を明示しています。
+
+### `init(server:delegate:client:)`
+
+```swift
+override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
+    super.init(server: server, delegate: delegate, client: inputClient)
+
+    if candWindow == nil {
+        candWindow = CandidateWindow()
+    }
+
+    if ws == nil {
+        if let dictPath = Bundle.main.path(forResource: "dict", ofType: "txt") {
+            ws = WordSearch(connectionDictFile: dictPath,
+                            localDictFile: Config.localDictFile,
+                            studyDictFile: Config.studyDictFile)
+        }
+    }
+
+    resetState()
+    GyaimController.shared = self
+}
+```
+
+ここで辞書をロードし、候補ウィンドウを作ります。`GyaimController.shared` は Google変換の非同期callbackなど、controllerインスタンスに戻って候補表示を更新したい箇所で使います。
+
+InputMethodKit ではクライアントアプリごとにcontrollerが作られることがあるため、`shared` を安易に万能singletonとして扱うのは危険です。この実装では「現在最後に作られたcontrollerへ非同期候補を返す」用途に限定しています。
+
+## 4. 変換状態の持ち方
+
+SwiftyGyaim は、未確定入力をローマ字の `inputPat` として保持します。
+
+```swift
+private var inputPat = ""
+private var candidates: [SearchCandidate] = []
+private var nthCand = 0
+private var searchMode = 0
+
+private var converting: Bool {
+    !inputPat.isEmpty
+}
+```
+
+つまり `にほん` と入力中に見えていても、内部状態は `nihon` です。画面に出す未確定テキストやfallback候補は `RomaKana` で都度変換します。
+
+この方式の利点は、辞書のreadingもローマ字で統一できることです。一方で、かな入力そのものを主状態にするIMEとは設計が違うので、`inputPat` と表示文字列のズレに注意が必要です。
+
+## 5. キー入力: `handle(_:client:)`
+
+キー入力はすべてここに来ます。
+
+```swift
+override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
+    guard event.type == .keyDown else { return false }
+    ...
+}
+```
+
+戻り値は「このイベントをIMEが処理したか」です。`true` を返すと入力先アプリには渡りません。`false` だと通常キーとしてアプリに渡ります。
+
+処理の並びは実装上かなり重要です。
+
+1. JISかな/英数キーを消費
+2. 変換中ショートカットを判定
+3. `event.characters` を読む
+4. 単キーショートカットを判定
+5. Backspace / Space / Enter / 数字キー / 通常文字を処理
+
+例えば `;` は通常なら入力文字ですが、変換中ならひらがな確定です。そのため通常文字追加より前に単キー確定を判定しています。
+
+## 6. 候補検索: `searchAndShowCands()`
+
+通常文字が入力されると、最後にここへ来ます。
+
+```swift
+inputPat += eventString
+searchAndShowCands(client: sender)
+searchMode = 0
+```
+
+`searchAndShowCands()` は `searchMode` によって候補構成を変えます。
+
+### prefix mode
+
+```swift
+let searchResults = ws.search(query: inputPat, searchMode: searchMode)
+let hiragana = rk.roma2hiragana(inputPat)
+candidates = Self.buildPrefixCandidates(
+    searchResults: searchResults,
+    inputPat: inputPat,
+    clipboardCandidate: clipboardCandidate,
+    selectedCandidate: selectedCandidate,
+    hiragana: hiragana
+)
+```
+
+prefix mode では、辞書候補に加えて以下を前後に差し込みます。
+
+- `inputPat` そのもの
+- クリップボード候補
+- 選択テキスト候補
+- 候補が少ない場合のひらがなfallback
+
+これらは辞書由来ではないので `CandidateSource.synthetic` や `.external` になります。
+
+### exact mode
+
+Enter時に `nthCand == 0` なら `searchMode = 1` にして完全一致検索します。
+
+```swift
+if searchMode == 1 {
+    candidates = ws.search(query: inputPat, searchMode: searchMode)
+    let katakana = rk.roma2katakana(inputPat)
+    candidates.insert(SearchCandidate(word: katakana), at: 0)
+    let hiragana = rk.roma2hiragana(inputPat)
+    candidates.insert(SearchCandidate(word: hiragana), at: 0)
+}
+```
+
+完全一致検索では、ひらがな/カタカナ候補を先頭に入れます。このモードは「明示的に変換しようとしている」状態なので、prefix modeよりも確定候補としてのかなを強く出します。
+
+## 7. 候補表示: `showCands()`
+
+`showCands()` は2つのことをします。
+
+1. 現在選択中の候補を marked text として入力先に表示
+2. 次候補のリストを `CandidateWindow` に渡す
+
+```swift
+let words = candidates.map(\.word)
+guard nthCand < words.count, let word = words[safe: nthCand] else { return }
+```
+
+選択中候補は `nthCand` です。候補ウィンドウに出す一覧は `nthCand + 1` から始まります。
+
+```swift
+for i in 0..<maxCandList {
+    let idx = nthCand + 1 + i
+    guard idx < words.count else { break }
+    candList.append(words[idx])
+}
+```
+
+この設計では「今marked textに出ている候補」と「候補ウィンドウに並ぶ次候補」が分かれます。
+
+marked text は次のように設定します。
+
+```swift
+let attrStr = NSAttributedString(string: word, attributes: attrs)
+client.setMarkedText(attrStr,
+    selectionRange: NSRange(location: word.count, length: 0),
+    replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+```
+
+`replacementRange` に `NSNotFound` を使うのは、現在のmarked textをIME側で置き換える一般的な使い方です。
+
+## 8. 確定: `fix()`
+
+確定処理は `fix(client:skipStudy:)` です。
+
+```swift
+let candidate = candidates[nthCand]
+let word = candidate.word
+let reading = candidate.reading ?? inputPat
+...
+client.insertText(word, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+```
+
+その後、学習や登録を行います。
+
+```swift
+if skipStudy {
+    ...
+} else {
+    let isExternalCandidate = (word == clipboardCandidate || word == selectedCandidate)
+    if isExternalCandidate {
+        ws?.register(word: word, reading: inputPat)
+    } else if let reading = candidate.reading {
+        ws?.study(word: word, reading: reading)
+    } else {
+        ws?.study(word: word, reading: inputPat)
+    }
+}
+```
+
+外部候補を確定した場合は、学習辞書ではなくユーザー辞書に登録します。これは「ユーザーがクリップボードや選択テキストから候補として明示的に選んだ語」は今後も出したい可能性が高い、という設計です。
+
+IME切替時の自動確定では `skipStudy: true` です。ユーザーが候補を選んだわけではないので学習しません。
+
+## 9. ウィンドウ位置: `showWindow()`
+
+候補ウィンドウ表示は、marked text更新とは別に `showWindow()` で行います。
+
+```swift
+var reportedLineRect = NSRect.zero
+client.attributes(forCharacterIndex: 0, lineHeightRectangle: &reportedLineRect)
+```
+
+この値は理想的にはスクリーン座標のキャレット行矩形です。しかし、Webアプリなどではローカル座標が返ることがあります。
+
+そこで次の解決処理を挟みます。
+
+```swift
+let resolution = CandidateWindowPositioner.resolveLineRect(
+    reportedLineRect: reportedLineRect,
+    previousValidLineRect: lastValidCandidateLineRect,
+    mouseLocation: NSEvent.mouseLocation)
+```
+
+`resolution.source` が `.reported` なら、次回fallback用に `lastValidCandidateLineRect` へ保存します。
+
+位置計算は `CandidateWindowPositioner.calculate()` に分けられています。これはAppKitに依存しすぎない純粋関数に近く、テストしやすくするためです。
+
+## 10. まとめ: SwiftyGyaimらしい実装ポイント
+
+SwiftyGyaim の実装は、複雑な形態素解析エンジンというより、「InputMethodKitの制約の中で、ローマ字入力・辞書検索・候補UIを小さくつなぐ」設計です。
+
+読解時の重要ポイントは次です。
+
+- 主状態は `inputPat` というローマ字文字列
+- 候補は `SearchCandidate` と `CandidateSource` で出自を持つ
+- `GyaimController` が入力状態・辞書・UIを束ねる
+- `WordSearch` は Study / Local / Connection の3層を統合する
+- 候補ウィンドウは `NSPanel.nonactivatingPanel` でフォーカスを奪わない
+- InputMethodKit の `sender` や `lineRect` は信用しすぎない
+- 学習辞書は複数controllerインスタンスを考えて static 共有する

--- a/docs/internal/testing-and-operations.md
+++ b/docs/internal/testing-and-operations.md
@@ -1,0 +1,167 @@
+# テスト・ビルド・運用
+
+## 開発ディレクトリ
+
+ビルドやテストの作業ディレクトリは `GyaimSwift/` です。
+
+```bash
+cd GyaimSwift
+```
+
+## Xcodeプロジェクト生成
+
+このリポジトリは XcodeGen を使います。
+
+```bash
+xcodegen generate
+```
+
+設定は `GyaimSwift/project.yml` にあります。
+
+## ビルド
+
+```bash
+xcodebuild -project Gyaim.xcodeproj \
+  -scheme Gyaim \
+  -configuration Debug \
+  -derivedDataPath .build \
+  build
+```
+
+成果物:
+
+```text
+GyaimSwift/.build/Build/Products/Debug/SwiftyGyaim.app
+```
+
+## ユニットテスト
+
+現在の推奨コマンド:
+
+```bash
+./Scripts/run-unit-tests.sh
+```
+
+このスクリプトは以下を行います。
+
+1. `xcodebuild build-for-testing`
+2. `.xctest` の拡張属性をクリア
+3. `xcrun xctest` でテスト実行
+
+背景として、ローカルmacOS/Xcode環境で `xcodebuild ... test` が `Cannot find executable for CFBundle` を出すことがあります。実際には `Contents/MacOS/GyaimTests` が存在しており、`.xctest` に付いた `com.apple.provenance` などの拡張属性がローダー失敗を引き起こすケースがあります。
+
+`run-unit-tests.sh` はこの問題を避けるためのローカル/CI共通入口です。
+
+## テスト構成
+
+| スイート | 役割 |
+|---|---|
+| `HandleEventTests` | キー入力分岐 |
+| `GoogleTransliterateTests` | Google変換候補生成・API応答処理 |
+| `ExternalCandidateTests` | 外部候補validation |
+| `PreferencesWindowTests` | 設定UI |
+| `CandidateWindowTests` | 候補UI、表示モード、位置計算 |
+| `CopyTextTests` | クリップボード候補 |
+| `RomaKanaTests` | ローマ字かな変換 |
+| `WordSearchTests` | 辞書検索・学習・削除 |
+| `StudyEntryTests` | 学習辞書entry・score |
+| `CryptTests` | 暗号化/復号 |
+| `ConnectionDictTests` | 連接辞書 |
+
+現在のユニットテストは 222 tests です。
+
+## E2Eテスト
+
+```bash
+xcodebuild -project Gyaim.xcodeproj \
+  -scheme GyaimE2ETests \
+  -derivedDataPath .build \
+  test
+```
+
+E2Eはアクセシビリティ権限とインストール済みSwiftyGyaimが必要です。`CGEvent` でTextEditを操作します。
+
+## ローカルインストール
+
+```bash
+killall SwiftyGyaim 2>/dev/null || true
+rm -rf ~/Library/Input\ Methods/SwiftyGyaim.app
+cp -r .build/Build/Products/Debug/SwiftyGyaim.app ~/Library/Input\ Methods/
+```
+
+反映されない場合:
+
+- 入力ソースを切り替える
+- `killall SwiftyGyaim`
+- ログアウト/ログイン
+
+## リリース
+
+リリースは tag push で `.github/workflows/release.yml` が動きます。
+
+```bash
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+workflow内容:
+
+1. checkout
+2. XcodeGen install
+3. `xcodegen generate`
+4. `./Scripts/run-unit-tests.sh`
+5. Debug build
+6. DMG作成
+7. GitHub Release作成
+
+## ログ確認
+
+ファイルログ:
+
+```bash
+tail -f ~/.gyaim/gyaim.log
+```
+
+Unified logging:
+
+```bash
+log stream --predicate 'subsystem == "com.pitecan.inputmethod.SwiftyGyaim"' --level debug
+```
+
+ログがデバッグの邪魔な場合:
+
+```bash
+: > ~/.gyaim/gyaim.log
+: > ~/.gyaim/gyaim.log.1
+: > ~/.gyaim/debug.log
+```
+
+## 変更時の運用ルール
+
+### Swiftファイルを編集する場合
+
+`docs/specs/` の対応specを先に読む必要があります。
+
+| 編集対象 | 読むspec |
+|---|---|
+| `GyaimController.swift` | `input-flow.md`, `imk-constraints.md` |
+| `WordSearch.swift`, `ConnectionDict.swift` | `dictionary-system.md` |
+| `CandidateWindow.swift`, `PreferencesWindow.swift` | `candidate-window.md` |
+| `GoogleTransliterate.swift` | `google-transliterate.md` |
+| バグ修正 | `bug-memory.md` |
+
+### バグ修正時
+
+- `docs/specs/bug-memory.md` に追記
+- 仕様が変わるなら該当specも更新
+- 必要ならADRを追加
+
+### PR作成時
+
+必ず `--repo tanabe1478/SwiftyGyaim` を指定します。
+
+```bash
+gh pr create --repo tanabe1478/SwiftyGyaim --base master --head <branch>
+```
+
+省略するとフォーク元 `masui/GyaimMotion` に向かう可能性があります。


### PR DESCRIPTION
## Summary
- add `docs/internal/` as a Japanese source-code understanding guide
- document overall architecture, InputMethodKit/Swift IME API usage, input flow, dictionary system, candidate UI, feature-by-feature implementation, and test/operation workflow
- provide an index README with recommended reading order

## Testing
- not run (documentation-only change)
