### PR TITLE
Fix blank classic candidate window

### DIFF
--- a/GyaimSwift/Sources/Gyaim/CandidateWindow.swift
+++ b/GyaimSwift/Sources/Gyaim/CandidateWindow.swift
@@ -259,16 +259,22 @@ class CandidateWindow: NSPanel {
               let textContainer = textView.textContainer,
               let layoutManager = textView.layoutManager else { return }
 
-        let textWidth = classicMetrics.bubbleSize.width
+        let documentWidth = classicMetrics.bubbleSize.width
             - classicMetrics.contentInsets.left
             - classicMetrics.contentInsets.right
-            - textView.textContainerInset.width * 2
+        let textWidth = documentWidth - textView.textContainerInset.width * 2
         textContainer.size = NSSize(width: textWidth, height: .greatestFiniteMagnitude)
         layoutManager.ensureLayout(for: textContainer)
         let textHeight = layoutManager.usedRect(for: textContainer).height
             + textView.textContainerInset.height * 2
 
         let scrollHeight = max(textHeight, classicMetrics.minimumContentHeight)
+        textView.frame = NSRect(x: 0, y: 0, width: documentWidth, height: scrollHeight)
+        classicScrollView?.contentView.scroll(to: .zero)
+        if let clipView = classicScrollView?.contentView {
+            classicScrollView?.reflectScrolledClipView(clipView)
+        }
+
         let windowHeight = scrollHeight
             + classicMetrics.contentInsets.top
             + classicMetrics.contentInsets.bottom

--- a/GyaimSwift/Tests/GyaimTests/CandidateWindowTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/CandidateWindowTests.swift
@@ -76,6 +76,26 @@ final class CandidateWindowTests: XCTestCase {
         CandidateWindow.shared = nil
     }
 
+    func testClassicModeSizesTextViewForWrappedLongCandidates() {
+        CandidateDisplayMode.setCurrent(.classic)
+        let window = CandidateWindow()
+        let words = [
+            "sitei", "指定", "しているの？", "しているところはない？", "していますか？",
+            "しているところないの？", "していないよね？", "していませんか？", "している",
+            "しているのかを", "しているよね"
+        ]
+        window.updateCandidates(words, selectedIndex: 0, hasMore: true)
+
+        let textView = findClassicTextView(in: window)
+        XCTAssertNotNil(textView)
+        XCTAssertFalse(textView!.string.isEmpty)
+        XCTAssertGreaterThan(textView!.frame.width, 0)
+        XCTAssertGreaterThanOrEqual(textView!.frame.height, 79)
+        XCTAssertGreaterThanOrEqual(window.frame.height, 126)
+
+        CandidateWindow.shared = nil
+    }
+
     func testApplyDisplayModeSwitches() {
         CandidateDisplayMode.setCurrent(.list)
         let window = CandidateWindow()

--- a/docs/specs/bug-memory.md
+++ b/docs/specs/bug-memory.md
@@ -1,7 +1,7 @@
 # Spec: バグメモリ
 
 > Trigger: 全ファイル（デバッグ時に参照）
-> Last updated: 2026-05-05 (BUG-007追加)
+> Last updated: 2026-05-07 (BUG-008追加)
 
 ## 概要
 
@@ -115,6 +115,20 @@
   - 「実行ファイルが見つからない」エラーでも、実際にはInfo.plist混入や拡張属性が原因のローダー失敗である場合がある
   - XcodeGenでアプリソース/リソースをテストターゲットにも含める場合、アプリ用Info.plistをテストバンドルに流用しないこと
   - macOSのローカルセキュリティ属性に起因するテスト実行問題は、`build-for-testing` と `xcrun xctest` の分離で切り分けやすい
+
+### BUG-008: Classic候補ウィンドウが白紙になる
+
+- **発見日**: 2026-05-07
+- **症状**: `sitei` や `deki` など、候補数が多く長い候補列をClassic表示で出すと、candwin.pngの白いcontent areaだけが表示され候補文字が見えない。スペースを押すと実際には「指定」などに変換できるため、候補生成ではなく描画だけの問題
+- **影響**: 候補が存在するのに空白に見え、候補選択が困難になる
+- **原因**: Classic表示の `NSScrollView.documentView` である `NSTextView` に文字列は設定されていたが、折り返し高さ計算後に `textView.frame` を明示更新していなかった。documentViewのframeがゼロ/不適切なままになり、白いscrollView背景のみが描画されるケースがあった
+- **修正**:
+  - `resizeClassicToFit()` で `documentWidth` と `scrollHeight` を計算後、`textView.frame = NSRect(x: 0, y: 0, width: documentWidth, height: scrollHeight)` を設定
+  - scroll位置を `.zero` に戻し、`reflectScrolledClipView` でscrollViewに反映
+- **検証**: `testClassicModeSizesTextViewForWrappedLongCandidates` を追加し、`sitei` 相当の長い候補列で `NSTextView.string` が空でないこと、`textView.frame.width > 0`、最低高さ以上であることを確認
+- **教訓**:
+  - `NSScrollView` の `documentView` はAuto Layout制約外になりやすい。文字列設定とlayoutManager計算だけでなく、documentViewのframeを明示する
+  - 「候補は確定できるが表示だけ空白」は、候補生成ではなく `NSTextView` / `NSScrollView` の描画・documentViewサイズを疑う
 
 ## パターン集
 

--- a/docs/specs/candidate-window.md
+++ b/docs/specs/candidate-window.md
@@ -30,7 +30,9 @@ UserDefaultsキー: `candidateDisplayMode` (Int, 0=list, 1=classic, デフォル
 
 ## Classic背景の描画
 
-`ClassicBackgroundView`: candwin.pngを9スライス描画（上部/中央/下部をストレッチ）。候補数に応じて幅を可変。
+`ClassicBackgroundView`: candwin.pngを9スライス描画（上部/中央/下部をストレッチ）。候補数に応じて高さを可変。
+
+Classic表示は `NSScrollView` + `NSTextView` で候補文字列を表示する。長い候補列が折り返される場合、`layoutManager.usedRect(for:)` で必要な高さを計算した後、`NSTextView.frame` を `documentWidth x scrollHeight` に明示更新する。`documentView` のframeがゼロのままだと、白いcontent areaだけが表示され候補文字が見えないため、回帰テストで `textView.frame.width > 0` を確認する。
 
 ## 位置計算
 


### PR DESCRIPTION
## Summary
- Fix Classic candidate window showing a blank white content area for long/wrapped candidates like `sitei` and `deki`
- Explicitly size the `NSTextView` document view after measuring wrapped text height
- Reset scroll position after resizing
- Add a regression test using a `sitei`-like long candidate list
- Document BUG-008 in specs/bug-memory

## Tests
- `cd GyaimSwift && ./Scripts/run-unit-tests.sh` — 228 tests, 0 failures
