### PR TITLE
Fix Gictionary repository URL import

### DIFF
--- a/GyaimSwift/Sources/Gyaim/GictionaryConnectionImporter.swift
+++ b/GyaimSwift/Sources/Gyaim/GictionaryConnectionImporter.swift
@@ -48,6 +48,7 @@ enum GictionaryConnectionImporter {
     }
 
     static let sourceURLDefaultsKey = "connectionDictSourceURL"
+    static let recommendedDict2URLString = "https://raw.githubusercontent.com/masui/Gictionary/master/dict2.txt"
 
     static var sourceURLString: String {
         UserDefaults.standard.string(forKey: sourceURLDefaultsKey) ?? ""
@@ -60,11 +61,12 @@ enum GictionaryConnectionImporter {
     static func importFromURL(_ url: URL,
                               outputPath: String = Config.importedConnectionDictFile,
                               completion: @escaping (Result<ImportResult, Error>) -> Void) {
-        if url.isFileURL {
+        let sourceURL = normalizedSourceURL(from: url)
+        if sourceURL.isFileURL {
             DispatchQueue.global(qos: .userInitiated).async {
                 do {
-                    let result = try importData(Data(contentsOf: url), outputPath: outputPath)
-                    setSourceURLString(url.absoluteString)
+                    let result = try importData(Data(contentsOf: sourceURL), outputPath: outputPath)
+                    setSourceURLString(sourceURL.absoluteString)
                     completion(.success(result))
                 } catch {
                     completion(.failure(error))
@@ -73,7 +75,7 @@ enum GictionaryConnectionImporter {
             return
         }
 
-        URLSession.shared.dataTask(with: url) { data, _, error in
+        URLSession.shared.dataTask(with: sourceURL) { data, _, error in
             if let error {
                 completion(.failure(error))
                 return
@@ -84,12 +86,40 @@ enum GictionaryConnectionImporter {
             }
             do {
                 let result = try importData(data, outputPath: outputPath)
-                setSourceURLString(url.absoluteString)
+                setSourceURLString(sourceURL.absoluteString)
                 completion(.success(result))
             } catch {
                 completion(.failure(error))
             }
         }.resume()
+    }
+
+    static func normalizedSourceURL(from url: URL) -> URL {
+        guard url.scheme == "https" || url.scheme == "http",
+              url.host == "github.com" else {
+            return url
+        }
+
+        let pathParts = url.path.split(separator: "/").map(String.init)
+        guard pathParts.count >= 2 else { return url }
+        let owner = pathParts[0]
+        let repo = pathParts[1]
+
+        if pathParts.count == 2 {
+            return rawGitHubURL(owner: owner, repo: repo, branch: "master", filePath: "dict2.txt")
+        }
+
+        if pathParts.count >= 5, pathParts[2] == "blob" {
+            let branch = pathParts[3]
+            let filePath = pathParts.dropFirst(4).joined(separator: "/")
+            return rawGitHubURL(owner: owner, repo: repo, branch: branch, filePath: filePath)
+        }
+
+        return url
+    }
+
+    private static func rawGitHubURL(owner: String, repo: String, branch: String, filePath: String) -> URL {
+        URL(string: "https://raw.githubusercontent.com/\(owner)/\(repo)/\(branch)/\(filePath)")!
     }
 
     @discardableResult

--- a/GyaimSwift/Sources/Gyaim/PreferencesWindow.swift
+++ b/GyaimSwift/Sources/Gyaim/PreferencesWindow.swift
@@ -808,7 +808,7 @@ private extension PreferencesWindow {
         contentBox.addSubview(urlLabel)
 
         let urlField = NSTextField(frame: NSRect(x: 60, y: y - 2, width: 300, height: 24))
-        urlField.placeholderString = "https://raw.githubusercontent.com/masui/Gictionary/master/dict2.txt"
+        urlField.placeholderString = GictionaryConnectionImporter.recommendedDict2URLString
         urlField.stringValue = GictionaryConnectionImporter.sourceURLString
         contentBox.addSubview(urlField)
         connectionDictURLField = urlField
@@ -820,7 +820,7 @@ private extension PreferencesWindow {
         connectionDictImportButton = importBtn
 
         y -= 24
-        let hint = makeLabel("Gictionaryのdict2.txt形式を指定できます。成功後すぐに変換へ反映します")
+        let hint = makeLabel("推奨: masui/Gictionary のリポジトリURLまたは raw の dict2.txt URL。成功後すぐ反映します")
         hint.font = NSFont.systemFont(ofSize: 11)
         hint.textColor = .secondaryLabelColor
         hint.frame = NSRect(x: 20, y: y, width: 440, height: 18)
@@ -841,7 +841,8 @@ private extension PreferencesWindow {
     }
 
     @objc private func importConnectionDictionary() {
-        let raw = connectionDictURLField?.stringValue.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let rawInput = connectionDictURLField?.stringValue.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let raw = rawInput.isEmpty ? GictionaryConnectionImporter.recommendedDict2URLString : rawInput
         guard let url = URL(string: raw), let scheme = url.scheme, ["http", "https", "file"].contains(scheme) else {
             connectionDictStatusLabel?.stringValue = "URLが正しくありません"
             return

--- a/GyaimSwift/Tests/GyaimTests/GictionaryConnectionImporterTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/GictionaryConnectionImporterTests.swift
@@ -76,6 +76,22 @@ final class GictionaryConnectionImporterTests: XCTestCase {
         XCTAssertEqual(imported, original)
     }
 
+    func testGitHubRepositoryURLNormalizesToRecommendedDict2RawURL() throws {
+        let url = try XCTUnwrap(URL(string: "https://github.com/masui/Gictionary"))
+
+        let normalized = GictionaryConnectionImporter.normalizedSourceURL(from: url)
+
+        XCTAssertEqual(normalized.absoluteString, GictionaryConnectionImporter.recommendedDict2URLString)
+    }
+
+    func testGitHubBlobURLNormalizesToRawURL() throws {
+        let url = try XCTUnwrap(URL(string: "https://github.com/masui/Gictionary/blob/master/dict2.txt"))
+
+        let normalized = GictionaryConnectionImporter.normalizedSourceURL(from: url)
+
+        XCTAssertEqual(normalized.absoluteString, GictionaryConnectionImporter.recommendedDict2URLString)
+    }
+
     func testImportAlreadyConvertedTSVNormalizesRows() throws {
         let tsv = """
         # comment

--- a/GyaimSwift/Tests/GyaimTests/PreferencesWindowTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/PreferencesWindowTests.swift
@@ -51,6 +51,23 @@ final class PreferencesWindowTests: XCTestCase {
         return nil
     }
 
+    private func findLabel(containing text: String) -> NSTextField? {
+        guard let contentView = window.contentView else { return nil }
+        return findTextField(in: contentView) { $0.stringValue.contains(text) }
+    }
+
+    private func findTextField(in view: NSView, matching predicate: (NSTextField) -> Bool) -> NSTextField? {
+        for subview in view.subviews {
+            if let textField = subview as? NSTextField, predicate(textField) {
+                return textField
+            }
+            if let found = findTextField(in: subview, matching: predicate) {
+                return found
+            }
+        }
+        return nil
+    }
+
     private func findButton(in view: NSView, titled title: String) -> NSButton? {
         for subview in view.subviews {
             if let button = subview as? NSButton, button.title == title {
@@ -78,6 +95,11 @@ final class PreferencesWindowTests: XCTestCase {
     func testLogToggleExists() {
         let toggle = findCheckbox(titled: "ロギングを有効にする")
         XCTAssertNotNil(toggle, "ログトグルが見つからない")
+    }
+
+    func testConnectionDictionaryImportUsageHintExists() {
+        let hint = findLabel(containing: "リポジトリURLまたは raw の dict2.txt URL")
+        XCTAssertNotNil(hint, "接続辞書インポートで指定すべきURLの説明が見つからない")
     }
 
     // MARK: - Default state (both ON when UserDefaults unset)

--- a/docs/specs/bug-memory.md
+++ b/docs/specs/bug-memory.md
@@ -1,7 +1,7 @@
 # Spec: バグメモリ
 
 > Trigger: 全ファイル（デバッグ時に参照）
-> Last updated: 2026-05-07 (BUG-008追加)
+> Last updated: 2026-05-07 (BUG-009追加)
 
 ## 概要
 
@@ -129,6 +129,22 @@
 - **教訓**:
   - `NSScrollView` の `documentView` はAuto Layout制約外になりやすい。文字列設定とlayoutManager計算だけでなく、documentViewのframeを明示する
   - 「候補は確定できるが表示だけ空白」は、候補生成ではなく `NSTextView` / `NSScrollView` の描画・documentViewサイズを疑う
+
+### BUG-009: 接続辞書インポートでGitHubリポジトリURLを指定すると失敗する
+
+- **発見日**: 2026-05-07
+- **症状**: 設定画面の接続辞書URLに `https://github.com/masui/Gictionary` を入力してインポートすると「Gictionary JSONまたは接続辞書TSVとして解釈できません」と表示される
+- **影響**: UI上はGictionaryのURLを指定できそうに見えるが、実際にはGitHubのHTMLページをダウンロードしてしまいインポートできない
+- **原因**: `GictionaryConnectionImporter.importFromURL` が入力URLをそのまま `URLSession` に渡しており、GitHubリポジトリURLや `/blob/...` URLをrawファイルURLへ変換していなかった。UIの説明も `dict2.txt` raw URLが必要であることを明示していなかった
+- **修正**:
+  - `normalizedSourceURL(from:)` を追加し、`https://github.com/<owner>/<repo>` を `https://raw.githubusercontent.com/<owner>/<repo>/master/dict2.txt` へ正規化
+  - `https://github.com/<owner>/<repo>/blob/<branch>/<path>` もraw URLへ正規化
+  - URL欄が空の場合は推奨raw URLを使う
+  - UI文言とspecに、指定できるURL例と使い方を明記
+- **検証**: `testGitHubRepositoryURLNormalizesToRecommendedDict2RawURL`, `testGitHubBlobURLNormalizesToRawURL`, PreferencesWindowのURL説明テストを追加
+- **教訓**:
+  - URL入力UIでは「人間が貼りがちなURL」と「機械が取得すべきraw URL」を区別し、内部で正規化する
+  - 外部リポジトリ連携は、成功パスだけでなく実際にユーザーが貼るURL形式でテストする
 
 ## パターン集
 

--- a/docs/specs/candidate-window.md
+++ b/docs/specs/candidate-window.md
@@ -1,7 +1,7 @@
 # Spec: 候補ウィンドウ
 
 > Trigger: CandidateWindow.swift, PreferencesWindow.swift
-> Last updated: 2026-05-06 (接続辞書インポートUI追加)
+> Last updated: 2026-05-07 (接続辞書インポートURL説明更新)
 
 ## 概要
 
@@ -60,7 +60,7 @@ NSLayoutConstraintのactivation/deactivationで切り替え。list用のNSStackV
 
 設定画面に「接続辞書」セクションを追加。
 
-- URL入力欄: Gictionary `dict2.txt` 形式（接続辞書TSV）のURLを指定
+- URL入力欄: GictionaryリポジトリURLまたは `dict2.txt` raw URLを指定。空欄の場合は推奨raw URLを使う
 - 「インポート」ボタン: URLからダウンロードし、`~/.gyaim/connectiondict.txt` に変換・保存する
 - ステータス表示: 内蔵辞書/インポート辞書の利用状態、インポート件数、エラーを表示
 - 「内蔵辞書に戻す」ボタン: インポート済みファイルとURL設定を削除し、bundle内 `Resources/dict.txt` を再ロードする

--- a/docs/specs/dictionary-system.md
+++ b/docs/specs/dictionary-system.md
@@ -1,7 +1,7 @@
 # Spec: 辞書システム
 
 > Trigger: WordSearch.swift, ConnectionDict.swift
-> Last updated: 2026-05-06 (Gictionary接続辞書インポート)
+> Last updated: 2026-05-07 (Gictionary接続辞書インポートURL正規化)
 
 ## 概要
 
@@ -24,6 +24,17 @@ Connection: タブ区切り `romaji\tsurface\tinConnection\toutConnection`
 ## 接続辞書インポート
 
 設定画面の「接続辞書」セクションからURLを指定し、Gictionaryリポジトリの `dict2.txt` 形式（接続辞書TSV）を `~/.gyaim/connectiondict.txt` にインポートできる。`Gictionary.json` も読み込み可能だが、リポジトリ同梱の現行辞書と完全一致させたい場合は `dict2.txt` を指定する。
+
+### 使い方
+
+推奨URLは以下のいずれか。
+
+```text
+https://github.com/masui/Gictionary
+https://raw.githubusercontent.com/masui/Gictionary/master/dict2.txt
+```
+
+`https://github.com/masui/Gictionary` のようなGitHubリポジトリURLを指定した場合は、自動的に `https://raw.githubusercontent.com/masui/Gictionary/master/dict2.txt` として扱う。`/blob/<branch>/dict2.txt` URLもraw URLへ正規化する。未入力でインポートした場合も推奨raw URLを使用する。
 
 - UserDefaultsキー: `connectionDictSourceURL`（最後に成功したインポート元URL）
 - 保存先: `Config.importedConnectionDictFile` = `~/.gyaim/connectiondict.txt`


### PR DESCRIPTION
## Summary
- Fix connection dictionary import when users paste `https://github.com/masui/Gictionary`
- Normalize GitHub repository URLs to the recommended raw `dict2.txt` URL
- Normalize GitHub `/blob/<branch>/...` URLs to raw URLs
- Use the recommended raw URL when the URL field is empty
- Update the Preferences UI hint and specs with concrete usage examples
- Add regression tests for URL normalization and the UI usage hint

## Valid URL examples
- `https://github.com/masui/Gictionary`
- `https://raw.githubusercontent.com/masui/Gictionary/master/dict2.txt`
- `https://github.com/masui/Gictionary/blob/master/dict2.txt`

## Tests
- `cd GyaimSwift && ./Scripts/run-unit-tests.sh` — 231 tests, 0 failures
- Live raw URL smoke check: downloaded `https://raw.githubusercontent.com/masui/Gictionary/master/dict2.txt` and verified TSV columns
