### PR TITLE
Reject URL scheme external candidates

### DIFF
--- a/GyaimSwift/Sources/Gyaim/GyaimController.swift
+++ b/GyaimSwift/Sources/Gyaim/GyaimController.swift
@@ -639,10 +639,12 @@ class GyaimController: IMKInputController {
 
     /// Check if a string is a valid external candidate (not a Gyazo hash, not a URL).
     static func isValidExternalCandidate(_ s: String) -> Bool {
-        let trimmed = s.trimmingCharacters(in: .whitespaces)
+        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return false }
         if ImageManager.isImageCandidate(trimmed) { return false }
-        if trimmed.hasPrefix("http") { return false }
+        let lowercased = trimmed.lowercased()
+        if lowercased.hasPrefix("http") { return false }
+        if lowercased.contains("://") { return false }
         return true
     }
 

--- a/GyaimSwift/Tests/GyaimTests/ExternalCandidateTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/ExternalCandidateTests.swift
@@ -23,6 +23,8 @@ final class ExternalCandidateTests: XCTestCase {
     func testURLIsInvalid() {
         XCTAssertFalse(GyaimController.isValidExternalCandidate("https://example.com"))
         XCTAssertFalse(GyaimController.isValidExternalCandidate("http://example.com/path"))
+        XCTAssertFalse(GyaimController.isValidExternalCandidate("chrome-extension://nhlnjhfioadlgjgcldooopafglkkmcab/app.html"))
+        XCTAssertFalse(GyaimController.isValidExternalCandidate("obsidian://open?vault=notes"))
     }
 
     func testGyazoHashIsInvalid() {
@@ -226,6 +228,20 @@ final class ExternalCandidateTests: XCTestCase {
         )
         let words = result.map(\.word)
         XCTAssertFalse(words.contains("https://example.com/path"))
+    }
+
+    func testBuildSelectedCandidateRejectsChromeExtensionURL() {
+        let url = "chrome-extension://nhlnjhfioadlgjgcldooopafglkkmcab/app.html"
+        let result = GyaimController.buildPrefixCandidates(
+            searchResults: [SearchCandidate(word: "対象", reading: "taisyou")],
+            inputPat: "taisyou",
+            clipboardCandidate: nil,
+            selectedCandidate: url,
+            hiragana: "たいしょう"
+        )
+        let words = result.map(\.word)
+        XCTAssertFalse(words.contains(url))
+        XCTAssertEqual(words.prefix(2), ["taisyou", "対象"])
     }
 
     func testBuildSelectedCandidateRejectsWhitespace() {

--- a/docs/specs/bug-memory.md
+++ b/docs/specs/bug-memory.md
@@ -1,7 +1,7 @@
 # Spec: バグメモリ
 
 > Trigger: 全ファイル（デバッグ時に参照）
-> Last updated: 2026-05-30 (BUG-014追加)
+> Last updated: 2026-06-17 (BUG-015追加)
 
 ## 概要
 
@@ -210,6 +210,16 @@
 - **修正**: prefix mode の候補順を `raw input → クリップボード → 選択テキスト → 辞書検索結果 → ひらがな` に変更。raw input は Enter 誤確定防止のため先頭維持し、外部候補だけを辞書候補より前へ移動した。コピー後5秒以内の制約は維持。
 - **検証**: `ExternalCandidateTests` の候補順期待値を更新し、クリップボード/選択テキストが raw input 直後に並ぶことを確認。
 - **教訓**: `candidates` 内部順と候補ウィンドウ表示順は1つずれる（`showCands()` は `nthCand + 1` から表示）。登録UXを確認するときは、内部配列だけでなく表示上の第一候補を基準にする。
+
+### BUG-015: chrome-extension URL が選択テキスト候補として混入し誤学習される
+
+- **発見日**: 2026-06-17
+- **症状**: `taisyou` などの入力で `chrome-extension://.../app.html` が候補ウィンドウ先頭付近に表示され、誤って確定すると study 辞書へ学習される。ログには `Captured selected text: "chrome-extension://..."` と `Studied: "chrome-extension://..."` が残る。
+- **影響**: Chrome拡張ページのURLが日本語変換候補に混入し、削除しても再び選択テキスト候補として出ると再学習される。
+- **原因**: `isValidExternalCandidate()` が URL 除外を `hasPrefix("http")` だけで判定しており、`chrome-extension://` や `obsidian://` など URL scheme 形式の文字列を外部候補として許可していた。
+- **修正**: 外部候補検証で前後改行もtrimし、lowercase化した文字列が `://` を含む場合は無効とする。従来の `http` prefix と Gyazo hash 除外は維持。
+- **検証**: `ExternalCandidateTests` に `chrome-extension://...` / `obsidian://...` の無効化と、選択テキスト候補への混入防止テストを追加。
+- **教訓**: 外部候補は選択中テキスト・クリップボード由来で、アプリ内部URLやdeep linkも入りうる。URL判定は `http(s)` だけに限定せず、scheme形式全般を候補から除外する。
 
 ## パターン集
 

--- a/docs/specs/input-flow.md
+++ b/docs/specs/input-flow.md
@@ -1,7 +1,7 @@
 # Spec: キー入力フロー
 
 > Trigger: GyaimController.swift
-> Last updated: 2026-05-30 (外部候補を候補ウィンドウ先頭に表示)
+> Last updated: 2026-06-17 (URL scheme形式の外部候補を除外)
 
 ## 概要
 
@@ -70,7 +70,7 @@ deactivateServer(_:) → hideWindow, fix(skipStudy: true), 辞書finish
 
 ひらがなフォールバック: 候補数が `CandidateDisplayMode.current.maxVisible` 未満の場合、ひらがなを候補に追加。
 
-Prefix mode の候補順: `buildPrefixCandidates()` は raw `inputPat` を先頭に保ち、その後に外部候補（クリップボード、選択テキスト）、辞書検索結果、ひらがなフォールバックを並べる。raw `inputPat` を先頭にすることで、短い prefix 入力や完全一致前の入力で `gu` → `具体的`、`maeno` → `前のめり` のような長い prefix 候補が Enter / deactivate で誤確定されるのを防ぐ。一方、候補ウィンドウは `nthCand + 1` 以降を表示するため、コピー後5秒以内のクリップボード候補や選択テキスト候補は表示上の先頭に出る。
+Prefix mode の候補順: `buildPrefixCandidates()` は raw `inputPat` を先頭に保ち、その後に外部候補（クリップボード、選択テキスト）、辞書検索結果、ひらがなフォールバックを並べる。raw `inputPat` を先頭にすることで、短い prefix 入力や完全一致前の入力で `gu` → `具体的`、`maeno` → `前のめり` のような長い prefix 候補が Enter / deactivate で誤確定されるのを防ぐ。一方、候補ウィンドウは `nthCand + 1` 以降を表示するため、コピー後5秒以内のクリップボード候補や選択テキスト候補は表示上の先頭に出る。ただし、URLや `chrome-extension://...` のような URL scheme 形式の文字列は外部候補から除外する。
 
 ## 既知の制約
 


### PR DESCRIPTION
## Summary
- Reject external candidates containing URL schemes such as `chrome-extension://` and `obsidian://`
- Add regression tests for selected-text URL candidates
- Document BUG-015 and update input-flow spec

## Test
- `cd GyaimSwift && xcodegen generate && ./Scripts/run-unit-tests.sh`
  - 272 tests, 1 skipped, 0 failures

## Notes
- Also removed local `chrome-extension://` entries from `~/.gyaim/localdict.txt`
- Backup: `~/.gyaim/localdict.txt.bak-20260618040338`
