### PR TITLE
Add connection-dictionary suggestion CLI from local usage (#59)

### DIFF
--- a/GyaimSwift/Scripts/run-unit-tests.sh
+++ b/GyaimSwift/Scripts/run-unit-tests.sh
@@ -33,7 +33,8 @@ python3 -m py_compile \
   Tools/ai-rerank/sweep-fast-context-weights.py \
   Tools/ai-rerank/aggregate-fast-context-log.py \
   Tools/ai-rerank/train-fast-context-weights.py \
-  Tools/zenz-tuning/compare-hf-gguf.py
+  Tools/zenz-tuning/compare-hf-gguf.py \
+  Tools/dict/suggest-connection-entries.py
 python3 Tools/ai-rerank/validate-fast-context-eval-cases.py >/dev/null
 python3 Tools/ai-rerank/evaluate-fast-context-rerank.py --json >/dev/null
 # Quality gate (issue #57): fail CI when a non-model-required case misses top1,
@@ -57,6 +58,16 @@ assert report["results"]
 assert "delta" in report["results"][0]
 PY
 rm -f "$sweep_json"
+suggest_dir="$(mktemp -d)"
+printf 'kyokusho\t局所\t3\t4\nka\t*化\t4\t40\n' > "$suggest_dir/dict.txt"
+printf 'kyokushoka\t局所化\t100.0\t9\nzeijaku\t脆弱\t100.0\t7\n' > "$suggest_dir/study.txt"
+: > "$suggest_dir/local.txt"
+: > "$suggest_dir/log.txt"
+suggest_out="$(python3 Tools/dict/suggest-connection-entries.py --dict "$suggest_dir/dict.txt" \
+  --study "$suggest_dir/study.txt" --local "$suggest_dir/local.txt" --log "$suggest_dir/log.txt" --format tsv)"
+echo "$suggest_out" | grep -q "脆弱" || { echo "dict suggestion smoke failed: missing gap"; exit 1; }
+echo "$suggest_out" | grep -q "局所化" && { echo "dict suggestion smoke failed: composable word suggested"; exit 1; }
+rm -rf "$suggest_dir"
 review_cases_jsonl="$(mktemp)"
 python3 Tools/ai-rerank/extract-fast-context-review-cases.py --limit 1 > "$review_cases_jsonl"
 python3 Tools/ai-rerank/summarize-fast-context-review-labels.py "$review_cases_jsonl" >/dev/null

--- a/GyaimSwift/Tools/dict/suggest-connection-entries.py
+++ b/GyaimSwift/Tools/dict/suggest-connection-entries.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Suggest connection-dictionary additions from the user's own usage.
+
+First step of the "dictionary-growing workflow" (issue #59 方向性4, #29/#45):
+words the user actually committed — especially via the Google Transliterate
+fallback — that the connection dictionary cannot compose are, by definition,
+dictionary gaps. This tool mines studydict/localdict/gyaim.log for such words
+and emits reviewable TSV suggestion lines.
+
+Design constraints:
+- REVIEW REQUIRED: nothing is applied automatically. Suggested lines use the
+  general-noun class (3 -> 4, the dominant class in dict.txt). Verbs,
+  adjectives and particles need manual classes — see issue #45 for the
+  human-readable class mapping effort.
+- Privacy: reads only local files, sends nothing anywhere. The output may
+  contain private vocabulary — review before sharing.
+- Composability check is a Python port of ConnectionDict's bounded exact
+  search (ADR-022 constrainedCompositions), so a word that the dictionary can
+  already form as a compound (e.g. 局所化) is not suggested.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+INTERNAL_CONNECTION_LABELS = {
+    "い形容詞", "な形容詞", "形容詞語尾", "動詞語尾", "名詞接続", "終止接続", "連用接続",
+}
+
+GENERAL_NOUN_IN = 3
+GENERAL_NOUN_OUT = 4
+
+GOOGLE_RESULTS_RE = re.compile(r'Google Transliterate results for "([^"]+)": \[(.*)\]')
+FIXED_RE = re.compile(r'Fixed: "([^"]+)" \(reading: "([^"]+)"')
+
+
+@dataclass
+class Entry:
+    pat: str
+    raw_word: str
+    in_connection: int
+    out_connection: int
+
+    @property
+    def word(self) -> str:
+        return self.raw_word.replace("*", "")
+
+    @property
+    def can_start(self) -> bool:
+        return not self.raw_word.startswith("*") and self.raw_word not in INTERNAL_CONNECTION_LABELS
+
+    @property
+    def can_terminate(self) -> bool:
+        return not self.raw_word.endswith("*") and self.raw_word not in INTERNAL_CONNECTION_LABELS
+
+    @property
+    def contributes_surface(self) -> bool:
+        return self.raw_word not in INTERNAL_CONNECTION_LABELS
+
+
+class ConnectionDict:
+    """Python port of ConnectionDict's bounded exact composition search."""
+
+    def __init__(self, path: Path) -> None:
+        self.entries: list[Entry] = []
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                if line.startswith("#") or not line.strip():
+                    continue
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) < 2:
+                    continue
+                in_conn = int(parts[2]) if len(parts) > 2 and parts[2].isdigit() else 0
+                out_conn = int(parts[3]) if len(parts) > 3 and parts[3].isdigit() else 0
+                self.entries.append(Entry(parts[0], parts[1], in_conn, out_conn))
+        self.by_first_char: dict[str, list[Entry]] = {}
+        self.by_in_connection: dict[int, list[Entry]] = {}
+        for entry in self.entries:
+            if entry.pat:
+                if entry.can_start:
+                    self.by_first_char.setdefault(entry.pat[0], []).append(entry)
+                self.by_in_connection.setdefault(entry.in_connection, []).append(entry)
+
+    def compositions(self, pat: str, max_results: int = 50, max_depth: int = 8) -> set[str]:
+        results: set[str] = set()
+        self._enumerate(None, pat, "", 0, max_results, max_depth, results)
+        return results
+
+    def _enumerate(self, connection: int | None, pat: str, found: str, depth: int,
+                   max_results: int, max_depth: int, results: set[str]) -> None:
+        if len(results) >= max_results or depth >= max_depth or not pat:
+            return
+        if connection is None:
+            candidates = self.by_first_char.get(pat[0], [])
+        else:
+            candidates = self.by_in_connection.get(connection, [])
+        for entry in candidates:
+            if len(results) >= max_results:
+                return
+            next_word = found + entry.word if entry.contributes_surface else found
+            if pat == entry.pat:
+                if entry.can_terminate and next_word:
+                    results.add(next_word)
+            elif entry.pat and pat.startswith(entry.pat):
+                self._enumerate(entry.out_connection, pat[len(entry.pat):], next_word,
+                                depth + 1, max_results, max_depth, results)
+
+
+@dataclass
+class Suggestion:
+    reading: str
+    word: str
+    provenance: list[str] = field(default_factory=list)
+
+    @property
+    def suggested_line(self) -> str:
+        return f"{self.reading}\t{self.word}\t{GENERAL_NOUN_IN}\t{GENERAL_NOUN_OUT}"
+
+    @property
+    def is_google_origin(self) -> bool:
+        return any(p.startswith("google") for p in self.provenance)
+
+    @property
+    def study_frequency(self) -> int:
+        for p in self.provenance:
+            if p.startswith("study:freq="):
+                return int(p.split("=", 1)[1])
+        return 0
+
+
+def is_romaji_reading(reading: str) -> bool:
+    return len(reading) >= 2 and re.fullmatch(r"[a-z-]+", reading) is not None
+
+
+def is_japanese_char(ch: str) -> bool:
+    code = ord(ch)
+    return (0x3041 <= code <= 0x3096 or 0x30A0 <= code <= 0x30FF
+            or 0x3400 <= code <= 0x4DBF or 0x4E00 <= code <= 0x9FFF
+            or code in (0x3005, 0x3006, 0x3007, 0x30FC))
+
+
+def is_suggestable_word(word: str) -> bool:
+    if not 1 <= len(word) <= 16 or not all(is_japanese_char(ch) for ch in word):
+        return False
+    # All-hiragana words are usually kana spellings, conjugations or particles —
+    # wrong material for a general-noun entry. Kanji/katakana terms only.
+    return not all(0x3041 <= ord(ch) <= 0x3096 for ch in word)
+
+
+def load_study_pairs(path: Path, min_frequency: int) -> dict[tuple[str, str], int]:
+    pairs: dict[tuple[str, str], int] = {}
+    if not path.exists():
+        return pairs
+    with path.open(encoding="utf-8", errors="replace") as f:
+        for line in f:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) >= 4 and parts[3].isdigit() and int(parts[3]) >= min_frequency:
+                pairs[(parts[0], parts[1])] = int(parts[3])
+    return pairs
+
+
+def load_local_pairs(path: Path) -> set[tuple[str, str]]:
+    pairs: set[tuple[str, str]] = set()
+    if not path.exists():
+        return pairs
+    with path.open(encoding="utf-8", errors="replace") as f:
+        for line in f:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) >= 2 and parts[0] and parts[1]:
+                pairs.add((parts[0], parts[1]))
+    return pairs
+
+
+def load_google_commits(paths: list[Path]) -> set[tuple[str, str]]:
+    """(reading, word) pairs the user committed from Google Transliterate
+    results — proven gaps: the user needed the fallback for these."""
+    pairs: set[tuple[str, str]] = set()
+    recent_results: dict[str, set[str]] = {}
+    for path in paths:
+        if not path.exists():
+            continue
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                if match := GOOGLE_RESULTS_RE.search(line):
+                    words = set(re.findall(r'"([^"]+)"', match.group(2)))
+                    recent_results[match.group(1)] = words
+                    continue
+                if match := FIXED_RE.search(line):
+                    word, reading = match.group(1), match.group(2)
+                    if word in recent_results.get(reading, set()):
+                        pairs.add((reading, word))
+    return pairs
+
+
+def collect_suggestions(dictionary: ConnectionDict,
+                        study: dict[tuple[str, str], int],
+                        local: set[tuple[str, str]],
+                        google: set[tuple[str, str]]) -> list[Suggestion]:
+    merged: dict[tuple[str, str], Suggestion] = {}
+
+    def add(reading: str, word: str, provenance: str) -> None:
+        if not is_romaji_reading(reading) or not is_suggestable_word(word):
+            return
+        suggestion = merged.setdefault((reading, word), Suggestion(reading=reading, word=word))
+        suggestion.provenance.append(provenance)
+
+    for (reading, word), frequency in study.items():
+        add(reading, word, f"study:freq={frequency}")
+    for reading, word in local:
+        add(reading, word, "local")
+    for reading, word in google:
+        add(reading, word, "google")
+
+    suggestions = [s for s in merged.values() if s.word not in dictionary.compositions(s.reading)]
+    suggestions.sort(key=lambda s: (not s.is_google_origin, -s.study_frequency, s.reading))
+    return suggestions
+
+
+def print_report(suggestions: list[Suggestion], *, fmt: str, limit: int) -> None:
+    shown = suggestions[:limit]
+    if fmt == "tsv":
+        for suggestion in shown:
+            print(f"{suggestion.suggested_line}\t# {','.join(suggestion.provenance)}")
+        return
+    print("# Connection dictionary suggestions — REVIEW REQUIRED")
+    print()
+    print(f"{len(suggestions)} gap(s) found, showing {len(shown)}. "
+          f"Suggested class is 一般名詞 ({GENERAL_NOUN_IN} -> {GENERAL_NOUN_OUT}); "
+          "verbs/adjectives/particles need manual classes (#45). "
+          "Output may contain private vocabulary — do not share unreviewed.")
+    print()
+    for suggestion in shown:
+        marker = "★google" if suggestion.is_google_origin else ""
+        print(f"- [ ] `{suggestion.suggested_line}` — {','.join(suggestion.provenance)} {marker}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Suggest connection dictionary additions from local usage.")
+    parser.add_argument("--dict", type=Path, default=None,
+                        help="Connection dict TSV. Defaults to ~/.gyaim/connectiondict.txt "
+                             "if present, else the bundled Resources/dict.txt.")
+    parser.add_argument("--study", type=Path, default=Path.home() / ".gyaim/studydict.txt")
+    parser.add_argument("--local", type=Path, default=Path.home() / ".gyaim/localdict.txt")
+    parser.add_argument("--log", type=Path, action="append", default=None,
+                        help="gyaim.log files for Google-origin tagging. "
+                             "Defaults to ~/.gyaim/gyaim.log(.1).")
+    parser.add_argument("--min-frequency", type=int, default=5,
+                        help="Minimum study frequency for study-derived suggestions.")
+    parser.add_argument("--limit", type=int, default=50)
+    parser.add_argument("--format", choices=["markdown", "tsv"], default="markdown")
+    args = parser.parse_args()
+
+    dict_path = args.dict
+    if dict_path is None:
+        imported = Path.home() / ".gyaim/connectiondict.txt"
+        bundled = Path(__file__).resolve().parents[2] / "Resources/dict.txt"
+        dict_path = imported if imported.exists() and imported.stat().st_size > 0 else bundled
+    if not dict_path.exists():
+        print(f"ERROR: connection dict not found: {dict_path}", file=sys.stderr)
+        return 1
+
+    log_paths = args.log or [Path.home() / ".gyaim/gyaim.log.1", Path.home() / ".gyaim/gyaim.log"]
+    dictionary = ConnectionDict(dict_path)
+    suggestions = collect_suggestions(dictionary,
+                                      study=load_study_pairs(args.study, args.min_frequency),
+                                      local=load_local_pairs(args.local),
+                                      google=load_google_commits(log_paths))
+    print_report(suggestions, fmt=args.format, limit=args.limit)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/specs/dictionary-system.md
+++ b/docs/specs/dictionary-system.md
@@ -1,7 +1,7 @@
 # Spec: 辞書システム
 
 > Trigger: WordSearch.swift, ConnectionDict.swift
-> Last updated: 2026-07-08 (ConnectionDictの有界列挙API追加 — ADR-022)
+> Last updated: 2026-07-09 (辞書提案CLI追加 — issue #59 方向性4)
 
 ## 概要
 
@@ -87,6 +87,19 @@ https://raw.githubusercontent.com/masui/Gictionary/master/dict2.txt
 - 起動時/再読み込み時は `Config.activeConnectionDictFile(bundleDictPath:)` で、インポート済みファイルが存在し非空ならそれを使用し、なければbundle内 `Resources/dict.txt` を使用する
 - インポート成功後は `GyaimController.reloadConnectionDictionary()` で現在の `WordSearch` を作り直し、再起動せずに反映する
 - 「内蔵辞書に戻す」で `~/.gyaim/connectiondict.txt` とURL設定を削除し、bundle辞書を再ロードする
+
+### 辞書提案CLI（issue #59 方向性4）
+
+`Tools/dict/suggest-connection-entries.py` は、ユーザーの実使用から接続辞書の不足語を提案する。
+
+- 入力: `~/.gyaim/studydict.txt`（頻度閾値、既定5）/ `localdict.txt` / `gyaim.log`（Google Transliterate経由の確定 = 辞書の穴の実証）
+- 除外: 接続辞書で合成可能な語（ConnectionDictの有界exact探索のPython port）、全ひらがな語、非ローマ字reading、日本語以外の表記
+- 出力: レビュー用チェックリスト（`--format markdown`）または TSV 行（一般名詞 `3 -> 4` 想定）。**自動適用はしない**。動詞・形容詞・助詞類のクラスは手動判断（#45）
+- プライバシー: ローカルファイルのみ読み、外部送信しない。出力は私的語彙を含むためレビューなしで共有しない
+
+```bash
+python3 Tools/dict/suggest-connection-entries.py --limit 50
+```
 
 ### Gictionary JSON の解釈
 


### PR DESCRIPTION
## 概要

roadmap #62 / ワークストリーム #59 方向性4「辞書を育てるworkflow」の第一弾（#29 / #45 の布石）。

**「Googleフォールバックで確定した語 ＝ 接続辞書の穴の実証」**という #62 原則7 のループを、実際に回す道具を作る。

```bash
python3 Tools/dict/suggest-connection-entries.py --limit 50
```

- 入力: studydict（頻度閾値、既定5）/ localdict / gyaim.log（Google経由確定のタグ付け）
- 除外: **接続辞書で合成可能な語**（ConnectionDict有界exact探索のPython port＝ADR-022と同ロジック）、全ひらがな語、非ローマ字reading
- 出力: レビュー用チェックリスト or TSV（一般名詞 `3→4` 想定、dict.txtの支配クラス22,434件に基づく既定）
- **自動適用はしない**（動詞・形容詞のクラス判断は #45 の人間可読クラス整備後）。ローカル完結・外部送信なし

## 実データでの初回実行

手元の辞書・ログで **285件のギャップ**を検出。上位は `コンテキスト`（頻度32）、`凝集`、`打刻` など、実際に多用しているのに接続辞書にない語で、提案品質は実用レベル。

## 検証

- 361 unit tests / 0 failures
- run-unit-tests.sh に合成fixtureのsmoke（ギャップ検出 + 合成可能語の非提案）を追加
- spec `docs/specs/dictionary-system.md` に使い方とプライバシー方針を記載

## 次のステップ（このPRの範囲外）

- #45 のクラス情報整備 → 名詞以外の提案クラス対応
- golden corpus + 適用後の品質ゲート（ai-roadmap.md の Agentic Dictionary Workflow）

🤖 Generated with [Claude Code](https://claude.com/claude-code)