### PR TITLE
Add preference-pair extraction from dogfood commits (#57 / M6-1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Bidirectional romaji-kana conversion with 350+ rules in `rklist`. Includes full-
 ### テスト実行
 
 ```bash
-# ユニットテスト（361テスト）
+# ユニットテスト（364テスト）
 ./Scripts/run-unit-tests.sh
 
 # E2Eテスト（アクセシビリティ権限必要、Gyaimインストール済みの状態で実行）

--- a/GyaimSwift/Scripts/run-unit-tests.sh
+++ b/GyaimSwift/Scripts/run-unit-tests.sh
@@ -34,7 +34,8 @@ python3 -m py_compile \
   Tools/ai-rerank/aggregate-fast-context-log.py \
   Tools/ai-rerank/train-fast-context-weights.py \
   Tools/zenz-tuning/compare-hf-gguf.py \
-  Tools/dict/suggest-connection-entries.py
+  Tools/dict/suggest-connection-entries.py \
+  Tools/ai-rerank/extract-preference-pairs.py
 python3 Tools/ai-rerank/validate-fast-context-eval-cases.py >/dev/null
 python3 Tools/ai-rerank/evaluate-fast-context-rerank.py --json >/dev/null
 # Quality gate (issue #57): fail CI when a non-model-required case misses top1,
@@ -58,6 +59,12 @@ assert report["results"]
 assert "delta" in report["results"][0]
 PY
 rm -f "$sweep_json"
+pref_dir="$(mktemp -d)"
+printf '[2026-07-10 10:00:00] [input] [info] Fast context accepted detail: input="kousin" payload={"chosenRank":2,"context":"アプリを","top":[{"kind":"raw","rank":0,"word":"kousin"},{"kind":"exact","rank":1,"reading":"kousin","source":"study","studyFrequency":11,"word":"行進"},{"contextAffinity":0.75,"kind":"exact","rank":2,"reading":"kousinn","source":"study","studyFrequency":101,"word":"更新"}]}\n' > "$pref_dir/log.txt"
+python3 Tools/ai-rerank/extract-preference-pairs.py --log "$pref_dir/log.txt" > "$pref_dir/pref.jsonl" 2>/dev/null
+grep -q '"expectedTop": "更新"' "$pref_dir/pref.jsonl" || { echo "preference extraction smoke failed"; exit 1; }
+python3 Tools/ai-rerank/train-fast-context-weights.py "$pref_dir/pref.jsonl" --epochs 2 --json >/dev/null
+rm -rf "$pref_dir"
 suggest_dir="$(mktemp -d)"
 printf 'kyokusho\t局所\t3\t4\nka\t*化\t4\t40\n' > "$suggest_dir/dict.txt"
 printf 'kyokushoka\t局所化\t100.0\t9\nzeijaku\t脆弱\t100.0\t7\n' > "$suggest_dir/study.txt"

--- a/GyaimSwift/Sources/Gyaim/GyaimController.swift
+++ b/GyaimSwift/Sources/Gyaim/GyaimController.swift
@@ -1111,6 +1111,47 @@ class GyaimController: IMKInputController {
         return configured > 0 ? min(configured, 6) : 3
     }
 
+    /// Single-line JSON payload for preference-pair extraction (issue #57 /
+    /// M6-1): the committed candidate plus the displayed head of the list,
+    /// with the metadata the offline trainer needs (reading / source / kind /
+    /// studyFrequency / contextAffinity). Emitted only when fast-context
+    /// logging is enabled; parsed by extract-preference-pairs.py.
+    static func acceptedDetailPayload(candidates: [SearchCandidate],
+                                      chosenIndex: Int,
+                                      context: String,
+                                      headLimit: Int = 8,
+                                      affinityProvider: ((SearchCandidate) -> Double)? = nil) -> String? {
+        guard candidates.indices.contains(chosenIndex) else { return nil }
+
+        func encode(_ candidate: SearchCandidate, rank: Int) -> [String: Any] {
+            var item: [String: Any] = [
+                "rank": rank,
+                "word": candidate.word,
+                "source": String(describing: candidate.source),
+                "kind": candidate.kind.rawValue,
+            ]
+            if let reading = candidate.reading { item["reading"] = reading }
+            if let frequency = candidate.studyFrequency { item["studyFrequency"] = frequency }
+            let affinity = affinityProvider?(candidate)
+                ?? ContextDict.shared.affinity(context: context, reading: candidate.reading, word: candidate.word)
+            if affinity > 0 { item["contextAffinity"] = affinity }
+            return item
+        }
+
+        var top = candidates.prefix(headLimit).enumerated().map { encode($0.element, rank: $0.offset) }
+        if chosenIndex >= headLimit {
+            top.append(encode(candidates[chosenIndex], rank: chosenIndex))
+        }
+        let payload: [String: Any] = [
+            "chosenRank": chosenIndex,
+            "context": context,
+            "top": top,
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]),
+              let json = String(data: data, encoding: .utf8) else { return nil }
+        return json
+    }
+
     private static func appendingZenzAlternativeCandidates(to snapshot: [SearchCandidate],
                                                            query: String,
                                                            hiragana: String,
@@ -1329,6 +1370,11 @@ class GyaimController: IMKInputController {
             Log.input.info("Fast context accepted: input=\"\(self.inputPat)\" word=\"\(word)\" "
                 + "rank=\(self.nthCand) candidates=\(self.candidates.count) "
                 + "source=\(String(describing: candidate.source)) kind=\(candidate.kind.rawValue)")
+            if let payload = Self.acceptedDetailPayload(candidates: candidates,
+                                                        chosenIndex: nthCand,
+                                                        context: Self.limitedFastContext(recentCommittedText)) {
+                Log.input.info("Fast context accepted detail: input=\"\(self.inputPat)\" payload=\(payload)")
+            }
         }
 
         let resolvedClient = (sender as? IMKTextInput) ?? (self.client() as? IMKTextInput)

--- a/GyaimSwift/Tests/GyaimTests/AcceptedDetailPayloadTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/AcceptedDetailPayloadTests.swift
@@ -1,0 +1,66 @@
+@testable import Gyaim
+import XCTest
+
+/// Preference-pair extraction payload (issue #57 / M6-1).
+final class AcceptedDetailPayloadTests: XCTestCase {
+    private func makeCandidates() -> [SearchCandidate] {
+        [
+            SearchCandidate(word: "kousin", kind: .raw),
+            SearchCandidate(word: "行進", reading: "kousin", source: .study, kind: .exact, studyFrequency: 11),
+            SearchCandidate(word: "更新", reading: "kousinn", source: .study, kind: .exact, studyFrequency: 101),
+        ]
+    }
+
+    func testPayloadEncodesChosenRankMetadataAndAffinity() throws {
+        let payload = try XCTUnwrap(GyaimController.acceptedDetailPayload(
+            candidates: makeCandidates(),
+            chosenIndex: 2,
+            context: "アプリを",
+            affinityProvider: { $0.word == "更新" ? 0.75 : 0 }))
+
+        XCTAssertFalse(payload.contains("\n"), "payload must stay a single log line")
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any])
+        XCTAssertEqual(object["chosenRank"] as? Int, 2)
+        XCTAssertEqual(object["context"] as? String, "アプリを")
+
+        let top = try XCTUnwrap(object["top"] as? [[String: Any]])
+        XCTAssertEqual(top.count, 3)
+        let chosen = try XCTUnwrap(top.first { ($0["word"] as? String) == "更新" })
+        XCTAssertEqual(chosen["reading"] as? String, "kousinn")
+        XCTAssertEqual(chosen["studyFrequency"] as? Int, 101)
+        XCTAssertEqual(chosen["contextAffinity"] as? Double, 0.75)
+        XCTAssertEqual(chosen["rank"] as? Int, 2)
+
+        // Raw input carries no reading — the extractor drops it from pairs.
+        let raw = try XCTUnwrap(top.first { ($0["word"] as? String) == "kousin" })
+        XCTAssertNil(raw["reading"])
+    }
+
+    func testPayloadIncludesChosenBeyondHeadLimit() throws {
+        var candidates = makeCandidates()
+        for index in 0..<10 {
+            candidates.append(SearchCandidate(word: "候補\(index)",
+                                              reading: "kouho\(index)",
+                                              source: .connection,
+                                              kind: .prefix))
+        }
+
+        let payload = try XCTUnwrap(GyaimController.acceptedDetailPayload(
+            candidates: candidates,
+            chosenIndex: 12,
+            context: "",
+            affinityProvider: { _ in 0 }))
+
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any])
+        let top = try XCTUnwrap(object["top"] as? [[String: Any]])
+        XCTAssertEqual(top.count, 9, "head 8 plus the chosen candidate")
+        XCTAssertTrue(top.contains { ($0["rank"] as? Int) == 12 })
+    }
+
+    func testPayloadNilForInvalidIndex() {
+        XCTAssertNil(GyaimController.acceptedDetailPayload(candidates: [],
+                                                           chosenIndex: 0,
+                                                           context: "",
+                                                           affinityProvider: { _ in 0 }))
+    }
+}

--- a/GyaimSwift/Tools/ai-rerank/extract-preference-pairs.py
+++ b/GyaimSwift/Tools/ai-rerank/extract-preference-pairs.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Extract preference cases from dogfood logs (issue #57 / M6-1).
+
+A commit at rank >= 2 is a strong preference signal: the user cycled past the
+candidates displayed above and chose this one, so the chosen word should have
+outscored everything it beat. This tool converts `Fast context accepted
+detail:` log lines (single-line JSON payloads emitted by GyaimController)
+into eval-fixture-schema JSONL that both `evaluate-fast-context-rerank.py`
+and `train-fast-context-weights.py` consume directly.
+
+Privacy: reads only local logs, sends nothing anywhere. Redaction (on by
+default) drops cases containing ASCII-identifier-like words, URLs, emails or
+digit-heavy strings. The output still contains private Japanese vocabulary —
+review before sharing or committing as fixtures.
+
+Signal-quality notes (zenz-model-tuning.md M6-1):
+- deactivation commits never produce accepted logs (skipStudy path), so they
+  are excluded at the source
+- rank 1 commits are position-biased weak signals and are excluded by default
+  (--min-rank 1 to include them)
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+DETAIL_RE = re.compile(r'Fast context accepted detail: input="([^"]*)" payload=(\{.*\})\s*$')
+VALIDATOR_PATH = Path(__file__).with_name("validate-fast-context-eval-cases.py")
+
+REDACT_PATTERNS = [
+    re.compile(r"[A-Za-z0-9_@:/.\-]{6,}"),  # identifiers, paths, URLs, emails
+    re.compile(r"\d{4,}"),                   # long digit runs (IDs, phone numbers)
+]
+
+
+def load_validator():
+    spec = importlib.util.spec_from_file_location("fast_context_eval_validator", VALIDATOR_PATH)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"failed to load validator: {VALIDATOR_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def needs_redaction(text: str) -> bool:
+    return any(pattern.search(text) for pattern in REDACT_PATTERNS)
+
+
+def build_case(index: int, input_pat: str, payload: dict, *, min_rank: int, redact: bool) -> dict | None:
+    chosen_rank = payload.get("chosenRank")
+    top = payload.get("top")
+    if not isinstance(chosen_rank, int) or chosen_rank < min_rank or not isinstance(top, list):
+        return None
+
+    candidates = []
+    chosen_word = None
+    for item in sorted(top, key=lambda entry: entry.get("rank", 0)):
+        word = item.get("word")
+        reading = item.get("reading")
+        # Candidates without a reading (raw input, clipboard/selected text)
+        # carry no dictionary features and are excluded — which also keeps
+        # external text out of training data.
+        if not isinstance(word, str) or not word or not isinstance(reading, str) or not reading:
+            continue
+        rank = item.get("rank", 0)
+        if rank > chosen_rank:
+            continue  # the user never evaluated candidates below the commit
+        candidate = {
+            "text": word,
+            "reading": reading,
+            "source": item.get("source", "connection"),
+            "kind": item.get("kind", "exact"),
+        }
+        if isinstance(item.get("studyFrequency"), int):
+            candidate["studyFrequency"] = item["studyFrequency"]
+        if isinstance(item.get("contextAffinity"), (int, float)) and item["contextAffinity"] > 0:
+            candidate["contextAffinity"] = min(float(item["contextAffinity"]), 1.0)
+        candidates.append(candidate)
+        if rank == chosen_rank:
+            chosen_word = word
+
+    if chosen_word is None or len(candidates) < 2:
+        return None
+
+    context = payload.get("context") if isinstance(payload.get("context"), str) else ""
+    if redact:
+        texts = [candidate["text"] for candidate in candidates] + [context]
+        if any(needs_redaction(text) for text in texts):
+            return None
+
+    return {
+        "id": f"preference-{index:05d}",
+        "inputPat": input_pat,
+        # The log does not carry the kana form; the heuristic never reads it,
+        # so the romaji stands in to satisfy the schema.
+        "inputKana": input_pat,
+        "context": context,
+        "candidates": candidates,
+        "expectedTop": chosen_word,
+        "mustNotTop": [],
+        "tags": ["fast-context", "preference"],
+        "reason": f"dogfood preference: rank {chosen_rank} commit over {chosen_rank - 1} skipped candidate(s)",
+    }
+
+
+def extract(paths: list[Path], *, min_rank: int, redact: bool) -> tuple[list[dict], int]:
+    cases: list[dict] = []
+    redacted_or_skipped = 0
+    seen: set[tuple[str, str, str]] = set()
+    index = 1
+    for path in paths:
+        if not path.exists():
+            continue
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                match = DETAIL_RE.search(line)
+                if not match:
+                    continue
+                try:
+                    payload = json.loads(match.group(2))
+                except json.JSONDecodeError:
+                    redacted_or_skipped += 1
+                    continue
+                case = build_case(index, match.group(1), payload, min_rank=min_rank, redact=redact)
+                if case is None:
+                    redacted_or_skipped += 1
+                    continue
+                key = (case["inputPat"], case["expectedTop"], case["context"])
+                if key in seen:
+                    continue
+                seen.add(key)
+                cases.append(case)
+                index += 1
+    return cases, redacted_or_skipped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Extract preference cases from dogfood logs (M6-1).")
+    parser.add_argument("--log", type=Path, action="append", default=None,
+                        help="gyaim.log files. Defaults to ~/.gyaim/gyaim.log(.1).")
+    parser.add_argument("--min-rank", type=int, default=2,
+                        help="Minimum commit rank. rank>=2 = the user skipped candidates (strong signal).")
+    parser.add_argument("--no-redact", action="store_true",
+                        help="Keep cases containing ASCII identifiers / URLs / digit runs.")
+    parser.add_argument("--limit", type=int, default=0, help="Emit at most N cases (0 = all).")
+    args = parser.parse_args()
+
+    paths = args.log or [Path.home() / ".gyaim/gyaim.log.1", Path.home() / ".gyaim/gyaim.log"]
+    cases, skipped = extract(paths, min_rank=args.min_rank, redact=not args.no_redact)
+    if args.limit > 0:
+        cases = cases[: args.limit]
+
+    # Guarantee schema compatibility with the evaluator / trainer up front.
+    validator = load_validator()
+    validator.validate([dict(case, __line=i + 1) for i, case in enumerate(cases)])
+
+    for case in cases:
+        print(json.dumps(case, ensure_ascii=False))
+    print(f"# extracted={len(cases)} skippedOrRedacted={skipped}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/GyaimSwift/Tools/ai-rerank/validate-fast-context-eval-cases.py
+++ b/GyaimSwift/Tools/ai-rerank/validate-fast-context-eval-cases.py
@@ -62,6 +62,7 @@ KNOWN_TAGS = {
     "homophone",
     "context-affinity",
     "model-required",
+    "preference",
 }
 
 

--- a/docs/specs/ai-rerank.md
+++ b/docs/specs/ai-rerank.md
@@ -1,7 +1,7 @@
 # Spec: AI Rerank
 
 > Trigger: AIReranker.swift, CandidateGenerator.swift, ExternalCommandAIReranker, GyaimController AI rerank integration
-> Last updated: 2026-07-08 (辞書制約付き生成でkind=zenz自由生成を置換 — ADR-022)
+> Last updated: 2026-07-10 (preference data抽出 — M6-1)
 
 ## 概要
 
@@ -305,6 +305,8 @@ dogfood中は確定のたびに `Fast context accepted: input=... word=... rank=
 CI品質ゲート（issue #57）として、`evaluate-fast-context-rerank.py --gate` を `run-unit-tests.sh` から実行する。`model-required` タグ以外のケースの top1 miss、任意ケースの unsafe top、`model-required` 以外の exact demotion があれば非ゼロ終了し、CIをfailさせる。`model-required` ケース（heuristicでは解けない文脈依存同音異義語）は意図的な伸びしろとしてtop1/demotionチェックから除外する。
 
 dogfoodの週次確認は `python3 Tools/ai-rerank/aggregate-fast-context-log.py --last-minutes 10080` で行い、acceptedRanks（acceptedTop1Rate / rank分布）と byOutcome（fix率・latency p95）を見る。
+
+preference data（M6-1）は `extract-preference-pairs.py` で抽出する。確定時の `Fast context accepted detail:` ログ（`GyaimController.acceptedDetailPayload` が出す単一行JSON。表示上位8件+確定候補の reading / source / kind / studyFrequency / contextAffinity を含む）から、**rank 2以上の確定**（=上に表示されていた候補を飛ばして選んだ強い選好シグナル）を eval fixture と同一スキーマの JSONL に変換する。deactivation確定はaccepted ログ自体が出ないため源流で除外され、rank 1 確定は位置バイアスの弱シグナルとして既定除外（`--min-rank 1` で含められる）。redaction（既定ON）は ASCII識別子・URL・数字列を含むケースを落とす。出力は private語彙を含むため、レビューなしで共有・fixture化しない。
 
 feature weight の学習には `train-fast-context-weights.py` を使う。eval fixture（または同スキーマのpreference JSONL）から `expectedTop` vs 他候補の pairwise logistic regression で feature multiplier を学習し（1.0初期値・1.0方向へL2正則化・非負クランプ）、`--feature-weight` 引数として出力する。`model-required` タグ（heuristic featureでは解けない文脈依存同音異義語）は既定で学習から除外する。
 

--- a/docs/specs/input-flow.md
+++ b/docs/specs/input-flow.md
@@ -1,7 +1,7 @@
 # Spec: キー入力フロー
 
 > Trigger: GyaimController.swift
-> Last updated: 2026-07-08 (通常reviewの最小入力長ゲート追加)
+> Last updated: 2026-07-10 (確定詳細ログの追加 — M6-1)
 
 ## 概要
 
@@ -41,7 +41,7 @@ handle(_:client:) → routeEvent() → HandleResult
 
 | パス | メソッド | 学習 | 用途 |
 |------|---------|------|------|
-| Enter/数字キー | `fix(client:)` | あり | 通常確定（prefix mode の先頭候補が raw `inputPat` の場合のみ Enter は完全一致検索へ遷移）。study と同時に ContextDict へ `(文脈末尾, reading, word)` を記録。`aiRerankFastContextLoggingEnabled=true` かつ prefix mode の意図的確定では `Fast context accepted: ... rank=N` を出力し、accepted rank を dogfood 計測できる |
+| Enter/数字キー | `fix(client:)` | あり | 通常確定（prefix mode の先頭候補が raw `inputPat` の場合のみ Enter は完全一致検索へ遷移）。study と同時に ContextDict へ `(文脈末尾, reading, word)` を記録。`aiRerankFastContextLoggingEnabled=true` かつ prefix mode の意図的確定では `Fast context accepted: ... rank=N` と、preference抽出用の `Fast context accepted detail: ... payload={...}`（表示上位8件+確定候補のメタデータJSON）を出力する |
 | F6/`;` | `fixAsKana(hiragana: true)` | あり | ひらがな確定 |
 | F7/`q` | `fixAsKana(hiragana: false)` | あり | カタカナ確定 |
 | IME切替 | `fix(client:sender, skipStudy: true)` | **なし** | deactivation確定 |

--- a/docs/zenz-model-tuning-tasklist.md
+++ b/docs/zenz-model-tuning-tasklist.md
@@ -359,14 +359,18 @@ Definition of done:
 
 ### M6-1. preference data extraction
 
-- [ ] dogfood log から chosen / rejected pair を作る条件を定義する
-- [ ] 誤確定・番号選択・deactivation 確定を区別する
-- [ ] private data redaction を入れる
-- [ ] opt-in export command を作る
+- [x] dogfood log から chosen / rejected pair を作る条件を定義する
+  - rank>=2 の意図的確定を強シグナルとし、確定候補より上に表示されていた候補を rejected とする
+- [x] 誤確定・番号選択・deactivation 確定を区別する
+  - deactivation は accepted ログ自体が出ない（skipStudy経路）。rank1確定は位置バイアスとして既定除外
+- [x] private data redaction を入れる
+  - ASCII識別子・URL・数字列を含むケースを既定で除外（`--no-redact` でopt-out）
+- [x] opt-in export command を作る
+  - `Tools/ai-rerank/extract-preference-pairs.py`（手動実行、出力はレビュー必須）
 
 Definition of done:
 
-- [ ] 人間が確認可能な preference JSONL が作れる
+- [x] 人間が確認可能な preference JSONL が作れる（eval fixtureと同一スキーマ、trainerに直結）
 
 ### M6-2. pairwise reranker
 


### PR DESCRIPTION
## 概要

roadmap #62 / ワークストリーム #57 の残タスク M6-1。**重み学習パイプラインに実使用データを供給する**最後のピース。

`train-fast-context-weights.py`（pairwise学習）は存在していたが、学習元が飽和済みの手書きfixtureしかなく空回りしていた。本PRで「ユーザーが実際にスキップした候補 vs 選んだ候補」という本物の選好データが流れ込む。

## 実装

**Swift側**: 確定時（accepted rankログと同条件: logging有効・意図的確定・prefix mode）に、単一行JSONの詳細ログを追加

```
Fast context accepted detail: input="kousin" payload={"chosenRank":2,"context":"...","top":[{word,reading,source,kind,studyFrequency,contextAffinity}...]}
```

表示上位8件+確定候補のメタデータを含む。純関数 `acceptedDetailPayload` としてユニットテスト済み。

**Python側**: `extract-preference-pairs.py`

- **rank>=2 の確定のみ**を強シグナルとして採用（上に表示されていた候補を意図的に飛ばした事実）。rank1確定は位置バイアスの弱シグナルとして既定除外（`--min-rank 1` でopt-in）
- deactivation確定は accepted ログ自体が出ないため源流で除外
- redaction既定ON: ASCII識別子・URL・数字列を含むケースを破棄。reading無し候補（raw・クリップボード）も構造的に除外され、外部テキストが学習データに混入しない
- 出力は **eval fixtureと同一スキーマ**のJSONLで、`evaluate-fast-context-rerank.py` / `train-fast-context-weights.py` がそのまま食える（出力前にvalidator自己検証）

## 使い方（dogfood数日後）

```bash
python3 Tools/ai-rerank/extract-preference-pairs.py > /tmp/pref.jsonl
python3 Tools/ai-rerank/train-fast-context-weights.py /tmp/pref.jsonl
```

学習された multiplier が現行重みと有意に違えば、AIReranker の定数更新を検討する（#57 の次ステップ）。

## 検証

- 364 unit tests / 0 failures
- run-unit-tests.sh に end-to-end smoke（合成ログ行 → 抽出 → validator → trainer実行）
- spec 2本 + tasklist M6-1 チェックボックス完了、CLAUDE.md テスト数更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)