### PR TITLE
Cache settings file reads (fixes 4x fast-context latency regression, BUG-027)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Bidirectional romaji-kana conversion with 350+ rules in `rklist`. Includes full-
 ### テスト実行
 
 ```bash
-# ユニットテスト（370テスト）
+# ユニットテスト（373テスト）
 ./Scripts/run-unit-tests.sh
 
 # E2Eテスト（アクセシビリティ権限必要、Gyaimインストール済みの状態で実行）

--- a/GyaimSwift/Sources/Gyaim/GyaimController.swift
+++ b/GyaimSwift/Sources/Gyaim/GyaimController.swift
@@ -856,6 +856,10 @@ class GyaimController: IMKInputController {
         if model.contains("review-passed") { return "review-passed" }
         if model.contains("review") { return "review-applied" }
         if model.contains("swift-fast-context-heuristic") { return "heuristic" }
+        // Model backend disabled or unavailable → plain heuristic result.
+        // Review-path model strings also contain this substring but are
+        // matched by the earlier patterns, so this must stay last.
+        if model.contains("swift-local-heuristic") { return "heuristic" }
         return "fallback"
     }
 

--- a/GyaimSwift/Sources/Gyaim/GyaimSettings.swift
+++ b/GyaimSwift/Sources/Gyaim/GyaimSettings.swift
@@ -175,24 +175,72 @@ enum GyaimSettings {
         saveDictionary(dictionary)
     }
 
+    // BUG-027: settings reads happen on the per-keystroke hot path (several
+    // per rerank, and once per candidate via ContextDict.isEnabled). Reading
+    // and JSON-parsing ~/.gyaim/settings.json from disk on every call pushed
+    // the fast-context heuristic p50 from ~2ms to ~8ms. Cache the parsed
+    // dictionary and invalidate on file modification date (same hot-reload
+    // semantics as localdict), so a read costs one stat() plus a lookup.
+    private static let cacheLock = NSLock()
+    private static var cachedDictionary: [String: Any] = [:]
+    private static var cachedPath: String?
+    private static var cachedModificationDate: Date?
+    private static var lastValidationTime: CFAbsoluteTime = 0
+    /// How long cached reads skip the modification-date check. Even stat()
+    /// (~0.4ms via attributesOfItem) is too slow at 24 calls per keystroke, so
+    /// external edits to settings.json are picked up within this interval
+    /// instead of immediately. Tests set 0 to revalidate on every read.
+    static var cacheRevalidationInterval: TimeInterval = 0.2
+
     private static func loadDictionary() -> [String: Any] {
-        let url = URL(fileURLWithPath: settingsFilePath)
-        guard let data = try? Data(contentsOf: url), !data.isEmpty else { return [:] }
-        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return [:] }
-        return object
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        let path = settingsFilePath
+        let now = CFAbsoluteTimeGetCurrent()
+        if path == cachedPath, now - lastValidationTime < cacheRevalidationInterval {
+            return cachedDictionary
+        }
+
+        let modificationDate = fileModificationDate(path)
+        if path == cachedPath, modificationDate == cachedModificationDate {
+            lastValidationTime = now
+            return cachedDictionary
+        }
+
+        var dictionary: [String: Any] = [:]
+        if let data = try? Data(contentsOf: URL(fileURLWithPath: path)), !data.isEmpty,
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            dictionary = object
+        }
+        cachedDictionary = dictionary
+        cachedPath = path
+        cachedModificationDate = modificationDate
+        lastValidationTime = now
+        return dictionary
     }
 
     private static func saveDictionary(_ dictionary: [String: Any]) {
-        let url = URL(fileURLWithPath: settingsFilePath)
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        let path = settingsFilePath
+        let url = URL(fileURLWithPath: path)
         do {
             try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
                                                     withIntermediateDirectories: true)
             let data = try JSONSerialization.data(withJSONObject: dictionary,
                                                   options: [.prettyPrinted, .sortedKeys])
             try data.write(to: url, options: .atomic)
+            cachedDictionary = dictionary
+            cachedPath = path
+            cachedModificationDate = fileModificationDate(path)
+            lastValidationTime = CFAbsoluteTimeGetCurrent()
         } catch {
             Log.config.error("Failed to save settings file: \(error.localizedDescription)")
         }
+    }
+
+    private static func fileModificationDate(_ path: String) -> Date? {
+        (try? FileManager.default.attributesOfItem(atPath: path)[.modificationDate]) as? Date
     }
 
     private static func jsonValue(from value: Any) -> Any? {

--- a/GyaimSwift/Tests/GyaimTests/GyaimSettingsTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/GyaimSettingsTests.swift
@@ -11,12 +11,14 @@ final class GyaimSettingsTests: XCTestCase {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         settingsURL = tempDir.appendingPathComponent("settings.json")
         GyaimSettings.settingsFilePathOverride = settingsURL.path
+        GyaimSettings.cacheRevalidationInterval = 0
         UserDefaults.standard.removeObject(forKey: "settingsTestFlag")
         UserDefaults.standard.removeObject(forKey: "settingsTestData")
     }
 
     override func tearDownWithError() throws {
         GyaimSettings.settingsFilePathOverride = nil
+        GyaimSettings.cacheRevalidationInterval = 0.2
         UserDefaults.standard.removeObject(forKey: "settingsTestFlag")
         UserDefaults.standard.removeObject(forKey: "settingsTestData")
         if let tempDir {
@@ -34,6 +36,50 @@ final class GyaimSettingsTests: XCTestCase {
         let data = try Data(contentsOf: settingsURL)
         let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         XCTAssertEqual(object?["settingsTestFlag"] as? Bool, true)
+    }
+
+    func testCachedReadsReflectExternalFileEdits() throws {
+        // BUG-027: reads are served from an mtime-invalidated cache. An
+        // external edit to settings.json (different modification date) must
+        // still be picked up — same hot-reload semantics as localdict.
+        GyaimSettings.set(true, forKey: "settingsTestFlag")
+        XCTAssertTrue(GyaimSettings.bool(forKey: "settingsTestFlag"))
+        UserDefaults.standard.removeObject(forKey: "settingsTestFlag")
+
+        let external = #"{"settingsTestFlag": false}"#
+        try Data(external.utf8).write(to: settingsURL, options: .atomic)
+
+        XCTAssertFalse(GyaimSettings.bool(forKey: "settingsTestFlag"))
+    }
+
+    func testCacheFollowsPathOverrideChanges() throws {
+        GyaimSettings.set(true, forKey: "settingsTestFlag")
+        XCTAssertTrue(GyaimSettings.bool(forKey: "settingsTestFlag"))
+        UserDefaults.standard.removeObject(forKey: "settingsTestFlag")
+
+        let otherURL = tempDir.appendingPathComponent("other-settings.json")
+        try Data(#"{"settingsTestFlag": false}"#.utf8).write(to: otherURL, options: .atomic)
+        GyaimSettings.settingsFilePathOverride = otherURL.path
+        defer { GyaimSettings.settingsFilePathOverride = settingsURL.path }
+
+        XCTAssertFalse(GyaimSettings.bool(forKey: "settingsTestFlag"))
+    }
+
+    func testRepeatedReadsAreServedFromCache() throws {
+        // Not a strict perf assertion — just guards the hot path against an
+        // accidental return to per-read disk parsing (BUG-027): 10k cached
+        // reads must finish far faster than 10k full file reads would.
+        GyaimSettings.cacheRevalidationInterval = 60
+        defer { GyaimSettings.cacheRevalidationInterval = 0 }
+        GyaimSettings.set(true, forKey: "settingsTestFlag")
+        _ = GyaimSettings.bool(forKey: "settingsTestFlag")
+
+        let start = CFAbsoluteTimeGetCurrent()
+        for _ in 0..<10_000 {
+            _ = GyaimSettings.bool(forKey: "settingsTestFlag")
+        }
+        let elapsedMs = (CFAbsoluteTimeGetCurrent() - start) * 1000
+        XCTAssertLessThan(elapsedMs, 500)
     }
 
     func testDataRoundTripUsesBase64EntryInSettingsJson() throws {

--- a/GyaimSwift/Tools/ai-rerank/aggregate-fast-context-log.py
+++ b/GyaimSwift/Tools/ai-rerank/aggregate-fast-context-log.py
@@ -131,7 +131,7 @@ def infer_outcome(model: str) -> str:
         return "review-passed"
     if "review" in model:
         return "review-applied"
-    if "swift-fast-context-heuristic" in model:
+    if "heuristic" in model:
         return "heuristic"
     return "fallback"
 

--- a/docs/specs/bug-memory.md
+++ b/docs/specs/bug-memory.md
@@ -1,7 +1,7 @@
 # Spec: バグメモリ
 
 > Trigger: 全ファイル（デバッグ時に参照）
-> Last updated: 2026-07-07 (BUG-026追加)
+> Last updated: 2026-07-11 (BUG-027追加)
 
 ## 概要
 
@@ -333,6 +333,16 @@
 - **修正**: `WordSearch.matchKind` に かな等価判定（`roma2hiragana(reading) == roma2hiragana(query)`）を追加し、かな等価readingへ `kind=exact` を付与。`AIReranker.isExactReadingMatch` / `ZenzRuntime.isProtectedExactReadingCandidate` は「辞書由来の `kind=exact` かつ reading 非nil」を exact として信頼する（外部候補は reading nil のため対象外）。`studyFrequencyBonus` の cap を 0.60 に引き上げ、頻度差でMRU逆転を可能にした。
 - **検証**: `WordSearchTests`（kousinn学習 → kousin検索で kind exact）、`AIRerankerTests`（更新が行進に勝つ・prefix penalty非適用・cap 0.60）、`ZenzRuntimeTests`（かな等価readingが同音異義語レビュー対象）、eval fixture `kana-variant-kousin-001` を追加。
 - **教訓**: ローマ字readingは同じかなに対して複数表記がある（`n`/`nn`、将来的には `si`/`shi`、`tu`/`tsu` も同種）。「読みの一致」を判定する箇所は文字列比較ではなくかな正規化後の比較にする。また対数ボーナスのcapは「区別したい実データの頻度域」（今回101 vs 11）を確認してから決める。
+
+### BUG-027: 設定ファイルの毎回読込でfast-contextレイテンシが4倍化
+
+- **発見日**: 2026-07-11
+- **症状**: dogfood集計で heuristic 経路の p50 が 2.1ms → 8.3ms に悪化（レイテンシゲート p95 < 2ms を大幅超過）。
+- **影響**: 全キーストロークの体感。設定を読むすべての経路が対象で、今後設定キーが増えるたびに悪化する構造だった。
+- **原因**: `GyaimSettings.loadDictionary()` が読み取りのたびに `~/.gyaim/settings.json` をディスクから読んでJSONパースしていた（キャッシュなし）。従来はrerank毎に数回で顕在化しなかったが、#70 で `ContextDict.isEnabled` を affinity 内（候補ごと＝キーストロークあたり最大24回）に置いたことで顕在化した。
+- **修正**: 設定辞書を mtime 無効化付きでキャッシュ（localdictと同じホットリロード方式）。読み取りは stat() 1回+辞書lookupになり、外部編集の反映は維持。`saveDictionary` はキャッシュも同時更新。あわせてモデル無効時の outcome ラベルを `fallback` → `heuristic` に修正（Swift側 `fastContextRerankOutcome`）。
+- **検証**: `GyaimSettingsTests` に外部編集の反映・パス切替追随・キャッシュ読み速度ガードを追加。
+- **教訓**: 設定読み取りAPIは「軽い」と仮定されて呼び出し側で自由に使われる。ホットパスに入りうる共有APIはキャッシュを内蔵し、コスト特性をAPI側で保証する。dogfoodのレイテンシ集計（byOutcome p50）は機能バグだけでなく性能バグも1日で検出できた。
 
 ## パターン集
 


### PR DESCRIPTION
## 概要

dogfoodレイテンシ集計（#57の基盤）が導入翌日に検出した性能バグの修正。

**症状**: heuristic経路の p50 が 2.1ms → 8.3ms に悪化（ゲート p95 < 2ms を大幅超過）。

**原因**: `GyaimSettings` が読み取りのたびに `~/.gyaim/settings.json` をディスクから読んでJSONパースしていた（キャッシュなし）。#70 で `ContextDict.isEnabled` を候補ごとの affinity 内に置いたため、**毎キーストローク最大24回のファイル読み**が発生。

## 修正

- パース済み辞書をキャッシュし、ファイル更新日時の再検証は**最大200msに1回**（stat() すら `attributesOfItem` 経由で ~0.4ms あり、候補ごとには重すぎるため）。外部編集は200ms以内に反映、プロセス内の書き込みはキャッシュを直接更新
- ついでに、モデル無効時の fast-context outcome が `fallback` と誤ラベルされていたのを `heuristic` に修正（テレメトリのみ、挙動変更なし）

## 検証

- 373 unit tests / 0 failures
- 新規テスト: 外部編集の反映 / パス切替の追随 / キャッシュ読み速度ガード（10,000回 < 500ms）
- bug-memory に BUG-027 追記

## 教訓（bug-memoryより）

設定読み取りAPIは「軽い」と仮定されて呼び出し側で自由に使われる。ホットパスに入りうる共有APIはコスト特性をAPI側で保証する。dogfoodのレイテンシ集計は機能バグだけでなく**性能バグも1日で検出**できた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)