### PR TITLE
Fix false positives in the study-suspect detector

### DIFF
--- a/GyaimSwift/Tools/dict/find-suspect-study-entries.py
+++ b/GyaimSwift/Tools/dict/find-suspect-study-entries.py
@@ -55,18 +55,33 @@ def load_entries(path: Path) -> list[StudyEntry]:
 
 
 def find_suspects(entries: list[StudyEntry], *, stale_days: int, now: float,
-                  dominance: int = 3) -> list[Suspect]:
+                  dominance: int = 3, max_garbage_frequency: int = 2) -> list[Suspect]:
     suspects: list[Suspect] = []
     frequency_by_word: dict[str, int] = {}
+    readings_by_word: dict[str, set[str]] = {}
     for entry in entries:
         frequency_by_word[entry.word] = max(frequency_by_word.get(entry.word, 0), entry.frequency)
+        readings_by_word.setdefault(entry.word, set()).add(entry.reading)
 
     stale_cutoff = now - stale_days * 24 * 3600
     for entry in entries:
-        if len(entry.word) >= 2:
+        # Real typo commits (BUG-025's してほしいい) have low frequency; a word
+        # committed dozens of times (今日 freq 45 next to 今 freq 166) is a
+        # legitimate word that merely shares a prefix. Weekly run 2026-07-21
+        # flagged 今日/今後/中身/上記 without this bound — all false positives.
+        if len(entry.word) >= 2 and entry.frequency <= max_garbage_frequency:
             shorter = entry.word[:-1]
             shorter_frequency = frequency_by_word.get(shorter, 0)
-            if shorter_frequency >= max(entry.frequency * dominance, entry.frequency + 2):
+            # A typo commit extends the shorter word's reading by a keystroke
+            # or two (sitehosiii = sitehosii + i). A different word that merely
+            # shares a surface prefix has an unrelated reading (文法 bunpou vs
+            # 文 bun, +3 chars) and must not be flagged.
+            reading_extends_shorter = any(
+                entry.reading.startswith(r) and 1 <= len(entry.reading) - len(r) <= 2
+                for r in readings_by_word.get(shorter, ())
+            )
+            if reading_extends_shorter and \
+               shorter_frequency >= max(entry.frequency * dominance, entry.frequency + 2):
                 suspects.append(Suspect(
                     entry, "garbage-completion",
                     f"「{shorter}」(freq {shorter_frequency}) の末尾1文字付きで freq {entry.frequency}"))
@@ -83,12 +98,16 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="List suspicious study-dictionary entries for manual review.")
     parser.add_argument("--study", type=Path, default=Path.home() / ".gyaim/studydict.txt")
     parser.add_argument("--stale-days", type=int, default=90)
+    parser.add_argument("--max-garbage-frequency", type=int, default=2,
+                        help="garbage-completion only fires for entries used at most this often; "
+                             "frequently committed words sharing a prefix are legitimate.")
     parser.add_argument("--limit", type=int, default=50)
     parser.add_argument("--format", choices=["markdown", "tsv"], default="markdown")
     args = parser.parse_args()
 
     entries = load_entries(args.study)
-    suspects = find_suspects(entries, stale_days=args.stale_days, now=time.time())
+    suspects = find_suspects(entries, stale_days=args.stale_days, now=time.time(),
+                             max_garbage_frequency=args.max_garbage_frequency)
     shown = suspects[: args.limit]
 
     if args.format == "tsv":


### PR DESCRIPTION
## 概要

週次メンテ実行で typo疑い検出CLIの誤検知を発見・修正。「今日」(freq 45)・「今後」(freq 29)・「中身」(freq 27)・「上記」(freq 24) が「今」「中」「上」の garbage-completion と誤判定されていた——表面のprefixを共有するだけの正当な高頻度語。

## 修正（BUG-025の実型に絞る2条件）

1. **エントリ自体が低頻度であること**（`--max-garbage-frequency`、既定2）: 数十回確定された語はtypoではない
2. **readingが短い方のreadingを1〜2打鍵だけ延長していること**（`sitehosiii` = `sitehosii`+i）: 表記prefixだけ共有する別語（`文法` bunpou vs `文` bun、+3文字）は対象外

## 検証

- 実データ: 高頻度語の誤検知が消滅（429件→本質的な低頻度疑いのみ）
- 合成: `してほしいい`(freq 1) は依然検出、`文法`(freq 2) は非検出
- 377 unit tests / 0 failures（既存smokeで検出維持を担保）

🤖 Generated with [Claude Code](https://claude.com/claude-code)