### PR TITLE
Add property-based testing harness and first invariant suites (formal methods Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ docs/gyaim-weekly-tasklist-template.md
 # Python cache
 __pycache__/
 *.pyc
+
+# LLVM profile data from manual xcrun xctest runs
+*.profraw
+
+# diffai review state
+.diffai/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Bidirectional romaji-kana conversion with 350+ rules in `rklist`. Includes full-
 ### テスト実行
 
 ```bash
-# ユニットテスト（377テスト）
+# ユニットテスト（383テスト）
 ./Scripts/run-unit-tests.sh
 
 # E2Eテスト（アクセシビリティ権限必要、Gyaimインストール済みの状態で実行）
@@ -115,6 +115,7 @@ xcodebuild -project Gyaim.xcodeproj -scheme GyaimE2ETests -derivedDataPath .buil
 | StudyEntryTests | Tests/GyaimTests/ | 9 | StudyEntryスコア計算・EvictionMode・ファイルI/O |
 | CryptTests | Tests/GyaimTests/ | 6 | 暗号化/復号のラウンドトリップ |
 | ConnectionDictTests | Tests/GyaimTests/ | 3 | 連接辞書の検索 |
+| プロパティテスト（3スイート） | Tests/GyaimTests/ | 6 | PropertyTesting.swiftハーネスによる不変条件検査（validatedOrderの順列性・学習マージの頻度保存・combineScoresのzero-sum性）。seed再現可能 |
 | GyaimE2ETests | Tests/E2ETests/ | 8 | CGEventによるIME統合テスト（TextEdit上で実操作） |
 
 ### テストインフラ

--- a/GyaimSwift/Tests/GyaimTests/PropertyTesting.swift
+++ b/GyaimSwift/Tests/GyaimTests/PropertyTesting.swift
@@ -1,0 +1,65 @@
+import XCTest
+
+/// Minimal property-based testing support (formal methods Phase 1).
+///
+/// A property test states an invariant that must hold for ALL inputs, then
+/// searches for a counterexample with hundreds of generated inputs. This is
+/// the lightest rung of the formal-methods ladder: the property is a formal
+/// specification, and the test is a bounded check of it.
+///
+/// Deliberately dependency-free (~60 lines) instead of importing SwiftCheck:
+/// the mechanism itself is a study artifact, and CI needs no network. The
+/// main trade-off is no shrinking — failures report the seed and iteration
+/// so the exact counterexample can be replayed deterministically.
+struct PropertyRandom {
+    /// SplitMix64: tiny, fast, deterministic. Not for cryptography — for
+    /// reproducible test-input generation only.
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        state = seed
+    }
+
+    mutating func nextRaw() -> UInt64 {
+        state &+= 0x9E3779B97F4A7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
+        z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
+        return z ^ (z >> 31)
+    }
+
+    mutating func int(in range: ClosedRange<Int>) -> Int {
+        let span = UInt64(range.upperBound - range.lowerBound) &+ 1
+        return range.lowerBound + Int(nextRaw() % span)
+    }
+
+    mutating func intArray(count: ClosedRange<Int>, element: ClosedRange<Int>) -> [Int] {
+        let length = int(in: count)
+        return (0..<length).map { _ in int(in: element) }
+    }
+}
+
+/// Runs `body` against `iterations` generated inputs. `body` returns nil when
+/// the property holds, or a description of the violation. On failure, the
+/// seed and iteration are reported so the counterexample can be replayed by
+/// passing the same seed.
+func checkProperty(_ label: String,
+                   iterations: Int = 300,
+                   seed: UInt64 = 0x5EED_5EED_5EED_5EED,
+                   file: StaticString = #filePath,
+                   line: UInt = #line,
+                   _ body: (inout PropertyRandom) -> String?) {
+    for iteration in 0..<iterations {
+        // Each iteration gets an independent, reproducible stream.
+        var random = PropertyRandom(seed: seed &+ UInt64(iteration))
+        if let violation = body(&random) {
+            XCTFail("""
+                property "\(label)" violated at iteration \(iteration) \
+                (replay with seed: \(seed &+ UInt64(iteration))): \(violation)
+                """,
+                    file: file,
+                    line: line)
+            return
+        }
+    }
+}

--- a/GyaimSwift/Tests/GyaimTests/RerankOrderPropertyTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/RerankOrderPropertyTests.swift
@@ -1,0 +1,44 @@
+@testable import Gyaim
+import XCTest
+
+/// Property tests for AIReranker.validatedOrder (formal methods Phase 1).
+///
+/// The existing example tests pin single inputs; these state the invariants
+/// that must hold for EVERY input. validatedOrder is the safety valve between
+/// any AI backend's response and the candidate list — if these properties
+/// break, candidates can vanish or duplicate no matter how good the model is.
+final class RerankOrderPropertyTests: XCTestCase {
+    func testValidatedOrderIsAlwaysAPermutation() {
+        checkProperty("validatedOrder returns a permutation of 0..<count for arbitrary input") { random in
+            let count = random.int(in: 0...30)
+            // Arbitrary garbage a backend could return: wrong length,
+            // duplicates, negatives, out-of-range indexes.
+            let proposed = random.intArray(count: 0...60, element: -5...40)
+
+            let order = AIReranker.validatedOrder(proposed, candidateCount: count)
+
+            guard order.count == count else {
+                return "length \(order.count) != count \(count) for proposed \(proposed)"
+            }
+            guard Set(order) == Set(0..<count) else {
+                return "not a permutation: \(order) for count \(count), proposed \(proposed)"
+            }
+            return nil
+        }
+    }
+
+    func testValidatedOrderIsIdempotent() {
+        checkProperty("re-validating a validated order changes nothing") { random in
+            let count = random.int(in: 0...30)
+            let proposed = random.intArray(count: 0...60, element: -5...40)
+
+            let once = AIReranker.validatedOrder(proposed, candidateCount: count)
+            let twice = AIReranker.validatedOrder(once, candidateCount: count)
+
+            guard once == twice else {
+                return "not idempotent: \(once) -> \(twice) for proposed \(proposed), count \(count)"
+            }
+            return nil
+        }
+    }
+}

--- a/GyaimSwift/Tests/GyaimTests/ScoreCombinationPropertyTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/ScoreCombinationPropertyTests.swift
@@ -1,0 +1,66 @@
+@testable import Gyaim
+import XCTest
+
+/// Property tests for BundledZenzRuntime.combineScores
+/// (formal methods Phase 1).
+///
+/// BUG-029 was exactly a violation of these properties: raw negative log
+/// probabilities were added to only the scored subset, systematically
+/// penalizing scored candidates against unscored ones. Stated as properties,
+/// the mistake is detectable for every weight and score distribution — not
+/// just the seisansei example pinned in the regression test.
+final class ScoreCombinationPropertyTests: XCTestCase {
+    func testZenzContributionIsZeroSumOverScoredSet() {
+        checkProperty("zenz contribution sums to zero over the scored set") { random in
+            let candidateCount = random.int(in: 1...20)
+            var heuristic: [Int: Double] = [:]
+            var zenz: [Int: Double] = [:]
+            for index in 0..<candidateCount {
+                heuristic[index] = Double(random.int(in: -300...300)) / 100.0
+                if random.int(in: 0...1) == 1 {
+                    // Mean log probabilities are negative — generate that shape.
+                    zenz[index] = Double(random.int(in: -1_000...0)) / 100.0
+                }
+            }
+            let weight = Double(random.int(in: 1...100)) / 100.0
+
+            let combined = BundledZenzRuntime.combineScores(heuristic: heuristic,
+                                                            zenz: zenz,
+                                                            weight: weight)
+
+            let contribution = zenz.keys.reduce(0.0) { sum, index in
+                sum + ((combined[index] ?? 0) - (heuristic[index] ?? 0))
+            }
+            guard abs(contribution) < 1e-9 else {
+                return "contribution sum \(contribution) != 0 for zenz \(zenz), weight \(weight)"
+            }
+            return nil
+        }
+    }
+
+    func testUnscoredCandidatesAreUntouched() {
+        checkProperty("candidates outside the scored set keep their heuristic score") { random in
+            let candidateCount = random.int(in: 1...20)
+            var heuristic: [Int: Double] = [:]
+            var zenz: [Int: Double] = [:]
+            for index in 0..<candidateCount {
+                heuristic[index] = Double(random.int(in: -300...300)) / 100.0
+                if random.int(in: 0...2) == 0 {
+                    zenz[index] = Double(random.int(in: -1_000...0)) / 100.0
+                }
+            }
+            let weight = Double(random.int(in: 1...100)) / 100.0
+
+            let combined = BundledZenzRuntime.combineScores(heuristic: heuristic,
+                                                            zenz: zenz,
+                                                            weight: weight)
+
+            for index in 0..<candidateCount where zenz[index] == nil {
+                if combined[index] != heuristic[index] {
+                    return "unscored index \(index) changed: \(String(describing: heuristic[index])) -> \(String(describing: combined[index]))"
+                }
+            }
+            return nil
+        }
+    }
+}

--- a/GyaimSwift/Tests/GyaimTests/StudyMergePropertyTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/StudyMergePropertyTests.swift
@@ -1,0 +1,53 @@
+@testable import Gyaim
+import XCTest
+
+/// Property tests for WordSearch.mergeKanaEquivalentStudyEntries
+/// (formal methods Phase 1).
+///
+/// The merge runs on every launch, so these are conservation laws:
+/// learning must be neither lost nor invented by the migration, and
+/// re-running it must be a no-op.
+final class StudyMergePropertyTests: XCTestCase {
+    /// Generates entries with overlapping readings/words so kana-equivalent
+    /// groups (kousin/kousinn shapes) actually occur.
+    private func makeEntries(_ random: inout PropertyRandom) -> [StudyEntry] {
+        let readings = ["kousin", "kousinn", "kinou", "seisansei", "sinkou", "sinnkou"]
+        let words = ["更新", "行進", "機能", "昨日", "生産性", "進行", "信仰"]
+        let count = random.int(in: 0...12)
+        return (0..<count).map { _ in
+            StudyEntry(reading: readings[random.int(in: 0...(readings.count - 1))],
+                       word: words[random.int(in: 0...(words.count - 1))],
+                       lastAccessTime: Double(random.int(in: 1_000...9_999)),
+                       frequency: random.int(in: 1...50))
+        }
+    }
+
+    func testMergeConservesTotalFrequency() {
+        checkProperty("merge neither loses nor invents learning (frequency sum is conserved)") { random in
+            let entries = makeEntries(&random)
+
+            let merged = WordSearch.mergeKanaEquivalentStudyEntries(entries)
+
+            let before = entries.reduce(0) { $0 + $1.frequency }
+            let after = merged.reduce(0) { $0 + $1.frequency }
+            guard before == after else {
+                return "frequency sum \(before) -> \(after) for \(entries)"
+            }
+            return nil
+        }
+    }
+
+    func testMergeIsIdempotent() {
+        checkProperty("merging an already-merged dictionary changes nothing") { random in
+            let entries = makeEntries(&random)
+
+            let once = WordSearch.mergeKanaEquivalentStudyEntries(entries)
+            let twice = WordSearch.mergeKanaEquivalentStudyEntries(once)
+
+            guard once == twice else {
+                return "not idempotent: \(once) -> \(twice)"
+            }
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
## 概要

形式手法ワークストリーム（#77）のPhase 1。依存ゼロの最小プロパティテストハーネスと、3スイート6性質を追加する。

## 内容

### ハーネス（PropertyTesting.swift）
- SplitMix64 PRNGによるseed再現可能な入力生成（`PropertyRandom`）
- `checkProperty(label, iterations: 300)`: 性質が破れた場合、seedとiterationを報告して決定的に再現可能
- SwiftCheck等の外部依存は導入しない（CIのネットワーク非依存、ハーネス自体が学習教材のため）。トレードオフはshrinking無し

### 性質（6テスト、1800生成入力、計 <2s）

| 対象 | 性質 | 封じるバグのクラス |
|------|------|------------------|
| `AIReranker.validatedOrder` | 任意のゴミ入力（長さ不正・重複・範囲外）に対して必ず0..<countの順列を返す / 冪等 | AIバックエンド応答による候補の消失・重複 |
| `WordSearch.mergeKanaEquivalentStudyEntries` | 頻度総和の保存 / 冪等 | 起動毎マイグレーションでの学習の喪失・水増し |
| `BundledZenzRuntime.combineScores` | Zenz寄与が採点集合上でzero-sum / 未採点候補は不変 | **BUG-029**（生logprob加算による採点候補への系統的ペナルティ）の再発 |

## テスト

- 全383テスト成功（1 skipped = model-required既存分）
- 全コミットはdiffaiブラウザレビューで承認済み

## 関連

- #77（形式手法ワークストリーム）
- ADR-009（routeEvent抽出とテスト戦略）

🤖 Generated with [Claude Code](https://claude.com/claude-code)