### PR TITLE
Exclude symbol-only candidates from exact-homophone review (BUG-031)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Bidirectional romaji-kana conversion with 350+ rules in `rklist`. Includes full-
 ### テスト実行
 
 ```bash
-# ユニットテスト（383テスト）
+# ユニットテスト（385テスト）
 ./Scripts/run-unit-tests.sh
 
 # E2Eテスト（アクセシビリティ権限必要、Gyaimインストール済みの状態で実行）

--- a/GyaimSwift/Sources/Gyaim/ZenzRuntime.swift
+++ b/GyaimSwift/Sources/Gyaim/ZenzRuntime.swift
@@ -646,9 +646,20 @@ final class BundledZenzRuntime: ZenzRuntime {
             if index != localOrder.first,
                isHiraganaOnlyText(candidate.text),
                candidate.text == request.hiragana { continue }
+            // The character LM systematically underrates symbol candidates
+            // (〇 scored -8.6 vs 円 -2.9 for reading まる), so a user's
+            // repeatedly chosen symbol kept losing the comparison no matter
+            // how often it was re-confirmed (BUG-031). Symbols never take
+            // part: as current best this skips the override entirely, and as
+            // challenger the LM would never fairly promote them anyway.
+            if isSymbolOnlyText(candidate.text) { continue }
             result.append(index)
         }
         return result
+    }
+
+    private static func isSymbolOnlyText(_ text: String) -> Bool {
+        !text.isEmpty && !text.contains(where: isJapaneseLike)
     }
 
     private static func isHiraganaOnlyText(_ text: String) -> Bool {

--- a/GyaimSwift/Tests/GyaimTests/ZenzRuntimeTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/ZenzRuntimeTests.swift
@@ -215,6 +215,75 @@ final class ZenzRuntimeTests: XCTestCase {
         XCTAssertEqual(indices, [0, 1])
     }
 
+    func testExactHomophoneCandidateIndicesExcludesSymbolOnlyCandidates() {
+        // BUG-031 (dogfood 2026-07-28): the user picked まる→〇 six times in a
+        // row and the exact-homophone review demoted it to 円 every time,
+        // because the character LM scores symbols systematically low
+        // (〇 -8.6 vs 円 -2.9). Symbol-only candidates never join the
+        // comparison; with the best excluded, the whole override is skipped.
+        let request = AIRerankRequest(
+            version: 1,
+            mode: "fast-context-rerank",
+            inputPat: "maru",
+            hiragana: "まる",
+            context: "〇円",
+            candidates: [
+                AIRerankCandidate(index: 0,
+                                  text: "〇",
+                                  reading: "maru",
+                                  source: "study",
+                                  kind: "exact"),
+                AIRerankCandidate(index: 1,
+                                  text: "円",
+                                  reading: "maru",
+                                  source: "study",
+                                  kind: "exact"),
+                AIRerankCandidate(index: 2,
+                                  text: "丸",
+                                  reading: "maru",
+                                  source: "study",
+                                  kind: "exact")
+            ]
+        )
+
+        let indices = BundledZenzRuntime.exactHomophoneCandidateIndices(request: request,
+                                                                        localOrder: [0, 1, 2])
+
+        // 〇 is excluded, so the caller's indices.contains(best) guard fails
+        // and the comparison is skipped — the kanji homophones alone must
+        // never be able to displace the user's protected symbol choice.
+        XCTAssertFalse(indices.contains(0))
+    }
+
+    func testExactHomophoneCandidateIndicesKeepsMixedSymbolKanjiCandidates() {
+        // Texts that merely contain a symbol alongside kana/kanji (〇円) are
+        // still fairly scorable and stay in the comparison.
+        let request = AIRerankRequest(
+            version: 1,
+            mode: "fast-context-rerank",
+            inputPat: "maruen",
+            hiragana: "まるえん",
+            context: "価格は",
+            candidates: [
+                AIRerankCandidate(index: 0,
+                                  text: "〇円",
+                                  reading: "maruen",
+                                  source: "study",
+                                  kind: "exact"),
+                AIRerankCandidate(index: 1,
+                                  text: "丸円",
+                                  reading: "maruen",
+                                  source: "study",
+                                  kind: "exact")
+            ]
+        )
+
+        let indices = BundledZenzRuntime.exactHomophoneCandidateIndices(request: request,
+                                                                        localOrder: [0, 1])
+
+        XCTAssertEqual(indices, [0, 1])
+    }
+
     func testExactHomophoneCandidateIndicesKeepsHiraganaWordThatIsNotRawSpelling() {
         // "ください" (input kudasa → raw spelling くださ) is a legitimate
         // hiragana word and must stay comparable (BUG-022 regression intent).

--- a/docs/specs/ai-rerank.md
+++ b/docs/specs/ai-rerank.md
@@ -1,7 +1,7 @@
 # Spec: AI Rerank
 
 > Trigger: AIReranker.swift, CandidateGenerator.swift, ExternalCommandAIReranker, GyaimController AI rerank integration
-> Last updated: 2026-07-14 (同音異義語レビューのaffinity加味margin)
+> Last updated: 2026-08-03 (同音異義語レビューから記号のみ候補を除外 BUG-031)
 
 ## 概要
 
@@ -152,7 +152,7 @@ SwiftyGyaim ではまず Swift local rerank の順で上位候補を評価し、
 
 fast-context rerank の model opt-in 経路では latency と安全性を優先し、Swift heuristic の最上位候補だけを1回 review する。`fixRequiredPrefix` は既存候補に prefix 一致する場合だけ先頭移動に使うが、通常のprefix予測では1文字 prefix を採用しない（`こうほ -> 高品質` や `つか... -> つかっちゃ` のような広すぎる置換を誘発しやすいため）。また現在の最上位候補自身に一致する prefix は順位変更として扱わず、local order を維持する。
 
-読み完全一致の `.exact` / `.compound` 最上位候補は、原則として model review で prefix 予測候補へ沈めない。ただし、左文脈があり、同じ読みの `.exact` / `.compound` 候補が複数ある場合（例: `muki` の `向き` / `無機`、`kinou` の `機能` / `昨日`）は exact 同音異義語レビューとして扱う（ADR-021）。この場合は `fixRequiredPrefix` 経由の置換ではなく、`exactHomophoneCandidateIndices` が返す protected exact 候補（既定上位3件、`aiRerankExactHomophoneMaxCandidates` で最大6）を `LlamaZenzContext.score` の条件付き平均logprobで**直接比較**する。未完成語幹（候補集合内に `語幹+い` または `っ` 終わり語幹の完成形が存在する候補、例: `ください` があるときの `くださ`）は比較対象から除外するため、モデルが未完成候補を昇格させることは構造上できない。また、**入力の生かな表記**（候補textが `request.hiragana` と一致するひらがなのみ候補）は、bestでない限り比較対象から除外する。文字レベルLMはかな列に系統的に高い確率を与えるため、`こみ` が `込み` に、`いっか` が `一家` に文脈と無関係に勝ってしまう（BUG-024）。生かな表記は heuristic 順・かな確定キー（`;` / `q`）から常に到達できるので失うものはなく、`ください`（入力 `kudasa` の生かな表記は `くださ`）のような正当なひらがな語は比較対象に残る。bestが生かな表記そのものの場合は除外せず、漢字同音異義語を上へ昇格できる。勝者が現在のbestを margin（`aiRerankExactHomophoneMargin`、既定0.10）**+ bestのcontextAffinity優位 × 2.0**（logprob単位）以上上回った場合のみ先頭を入れ替える。ユーザーが部分一致文脈（affinity < skip閾値0.75）で学習済みの選好を、モデルが僅差で覆すことを防ぐ（dogfood 2026-07-14: 学習済み `仕様` をモデルが `使用` へ再降格していた）。ログ outcome は `exact-homophone-fixed`（入れ替え）/ `exact-homophone-kept-local`（勝者が別候補だがmargin不足）/ `exact-homophone-passed`（bestが勝者）/ `exact-homophone-unavailable`（scoring失敗）を使う。
+読み完全一致の `.exact` / `.compound` 最上位候補は、原則として model review で prefix 予測候補へ沈めない。ただし、左文脈があり、同じ読みの `.exact` / `.compound` 候補が複数ある場合（例: `muki` の `向き` / `無機`、`kinou` の `機能` / `昨日`）は exact 同音異義語レビューとして扱う（ADR-021）。この場合は `fixRequiredPrefix` 経由の置換ではなく、`exactHomophoneCandidateIndices` が返す protected exact 候補（既定上位3件、`aiRerankExactHomophoneMaxCandidates` で最大6）を `LlamaZenzContext.score` の条件付き平均logprobで**直接比較**する。未完成語幹（候補集合内に `語幹+い` または `っ` 終わり語幹の完成形が存在する候補、例: `ください` があるときの `くださ`）は比較対象から除外するため、モデルが未完成候補を昇格させることは構造上できない。また、**入力の生かな表記**（候補textが `request.hiragana` と一致するひらがなのみ候補）は、bestでない限り比較対象から除外する。文字レベルLMはかな列に系統的に高い確率を与えるため、`こみ` が `込み` に、`いっか` が `一家` に文脈と無関係に勝ってしまう（BUG-024）。生かな表記は heuristic 順・かな確定キー（`;` / `q`）から常に到達できるので失うものはなく、`ください`（入力 `kudasa` の生かな表記は `くださ`）のような正当なひらがな語は比較対象に残る。bestが生かな表記そのものの場合は除外せず、漢字同音異義語を上へ昇格できる。対称に、**記号のみの候補**（かな・漢字を1文字も含まないtext、例: `〇` `△` `×`）は比較対象から**無条件に**除外する。文字レベルLMは記号に系統的に低い確率を与えるため（`まる` の `〇`=-8.60 vs `円`=-2.91）、ユーザーが繰り返し選んだ記号でも毎回漢字同音異義語に上書きされてしまう（BUG-031）。bestが記号の場合は比較自体がスキップされ、記号がchallengerとして昇格することもない。`〇円` のようにかな・漢字を含む混在テキストは比較に残る。勝者が現在のbestを margin（`aiRerankExactHomophoneMargin`、既定0.10）**+ bestのcontextAffinity優位 × 2.0**（logprob単位）以上上回った場合のみ先頭を入れ替える。ユーザーが部分一致文脈（affinity < skip閾値0.75）で学習済みの選好を、モデルが僅差で覆すことを防ぐ（dogfood 2026-07-14: 学習済み `仕様` をモデルが `使用` へ再降格していた）。ログ outcome は `exact-homophone-fixed`（入れ替え）/ `exact-homophone-kept-local`（勝者が別候補だがmargin不足）/ `exact-homophone-passed`（bestが勝者）/ `exact-homophone-unavailable`（scoring失敗）を使う。
 
 bestの `contextAffinity` が閾値（`aiRerankExactHomophoneAffinityThreshold`、既定0.75 = suffix一致3文字以上）以上の場合、同音異義語レビュー自体をスキップする（outcome `affinity-skip`）。ユーザーがその文脈で既に選んだ同音異義語をモデルが覆すべきではなく、レビューのレイテンシも節約できる。
 

--- a/docs/specs/bug-memory.md
+++ b/docs/specs/bug-memory.md
@@ -1,7 +1,7 @@
 # Spec: バグメモリ
 
 > Trigger: 全ファイル（デバッグ時に参照）
-> Last updated: 2026-08-03 (BUG-030追加)
+> Last updated: 2026-08-03 (BUG-031追加)
 
 ## 概要
 
@@ -373,6 +373,16 @@
 - **修正**: 入力の生ひらがな表記には ContextDict affinity bonusと文字数由来のexact bonusを適用しない。WordSearchのstudy/local検索では、文字列prefix一致に加えてかな等価readingも取得条件にし、exactPriorityのexactバケットにも双方向で含める。
 - **検証**: `AIRerankerTests` に頻度12の「文章」がaffinity 1.0・頻度6の「ぶんしょう」に勝つテスト、`WordSearchTests` に保存 `yondeite` を入力 `yonndeite` で `.study/.exact` として取得するテストを追加。
 - **教訓**: かな等価は候補取得後の分類だけでなく取得条件そのものに使う。生かな表記は専用確定経路で到達可能なので、文脈学習による自動昇格を漢字同音異義語と同じ強さで扱わない。
+
+### BUG-031: 記号候補がexact同音異義語レビューで毎回漢字に上書きされ、学習しても直らない
+
+- **発見日**: 2026-07-29
+- **症状**: dogfoodログ分析（rank≥2確定の週次レビュー）で、`maru`→`〇` が2分間に6回連続で `円` に負けていたことを発見。ユーザーが `〇` を選ぶたびに学習頻度は増える（最終的に〇=8 vs 円=1）のに、次の変換でまた `円` が1位になる。
+- **影響**: 記号（〇△×→・等）を読みで入力するユーザーの学習が exact 同音異義語レビューに毎回上書きされる。「選んでも直らないIME」という最悪のUX。文脈に確定済みの `円` が入ることでモデルスコアがさらに `円` に寄る悪循環もある。
+- **原因**: 文字レベルLMは散文コーパスで学習しており、記号に系統的に低い確率を与える（〇=-8.60 vs 円=-2.91、差5.69 logprob）。この差は affinity margin 防御（最大~2.0）では絶対に届かず、margin をそこまで上げると 更新/行進 のような正当な文脈修正が全滅する。**BUG-024（生かな表記の系統的過大評価）と対称の系統バイアス**（こちらは過小評価）。
+- **修正**: BUG-024と同じ構造的解決。`exactHomophoneCandidateIndices` で記号のみ候補（かな・漢字を1文字も含まない）を比較集合から無条件に除外。bestが記号の場合は `indices.contains(best)` ガードにより比較自体がスキップされ、challengerとしても昇格不能になる。
+- **検証**: `ZenzRuntimeTests.testExactHomophoneCandidateIndicesExcludesSymbolOnlyCandidates`（maru実データ再現）、`testExactHomophoneCandidateIndicesKeepsMixedSymbolKanjiCandidates`（〇円のような混在テキストは比較に残る）。
+- **教訓**: 文字レベルLMのスコアが信頼できない候補クラス（かな列=過大、記号=過小）は、margin調整ではなく**比較集合から構造的に除外**する。また「ユーザーが同じ修正を短時間に繰り返している」パターンはログ上で最優先の改善シグナル——学習が効いていない箇所を直接指している。
 
 ## パターン集
 


### PR DESCRIPTION
## 背景（dogfood 2026-07-29 週次ログ分析）

`maru`→`〇` が2分間に**6回連続**で exact 同音異義語レビューに `円` へ上書きされていた。ユーザーが `〇` を選ぶたびに学習頻度は増える（最終的に 〇=8 vs 円=1）のに、次の変換でまた `円` が1位になる——「選んでも直らないIME」状態。

## 原因

文字レベルLMは散文コーパス学習のため記号に系統的に低い確率を与える（実測: `〇`=-8.60 vs `円`=-2.91、差5.69 logprob）。この差は affinity margin 防御（最大~2.0）では構造的に届かず、marginを上げると 更新/行進 のような正当な文脈修正が全滅する。**BUG-024（生かな表記の系統的過大評価）と対称の系統バイアス**。

## 修正

BUG-024と同じ構造的解決: `exactHomophoneCandidateIndices` で**記号のみ候補**（かな・漢字を1文字も含まないtext）を比較集合から無条件除外。

- bestが記号 → 既存の `indices.contains(best)` ガードで比較自体がスキップ（モデルはユーザーの記号選択を降格できない）
- challengerとしても昇格不能（どのみちLMは記号を公平に採点できない）
- `〇円` のような混在テキストは比較に残る

本体は `isSymbolOnlyText` 述語＋除外1行のみ。

## テスト

- `testExactHomophoneCandidateIndicesExcludesSymbolOnlyCandidates`（maru実ログデータの回帰）
- `testExactHomophoneCandidateIndicesKeepsMixedSymbolKanjiCandidates`（境界）
- 全385テスト成功（1 skipped = model-required既存分）

## Spec更新

- `docs/specs/ai-rerank.md`: ADR-021段落に記号除外ルール追記
- `docs/specs/bug-memory.md`: BUG-030エントリ追加
- CLAUDE.md: テスト数 383→385

🤖 Generated with [Claude Code](https://claude.com/claude-code)