### PR TITLE
Secure Event Input対策: 非表示のASCII対応英数モードを追加 (issue #85)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Bidirectional romaji-kana conversion with 350+ rules in `rklist`. Includes full-
 ### テスト実行
 
 ```bash
-# ユニットテスト（390テスト）
+# ユニットテスト（395テスト）
 ./Scripts/run-unit-tests.sh
 
 # E2Eテスト（アクセシビリティ権限必要、Gyaimインストール済みの状態で実行）
@@ -104,6 +104,7 @@ xcodebuild -project Gyaim.xcodeproj -scheme GyaimE2ETests -derivedDataPath .buil
 | スイート | ファイル | テスト数 | 内容 |
 |---------|---------|---------|------|
 | HandleEventTests | Tests/GyaimTests/ | 45 | `routeEvent` 静的メソッドによるキー入力分岐の全網羅 |
+| InputModeTests | Tests/GyaimTests/ | 5 | TISモードID→InputModeマッピング（非表示英数モード、ADR-023） |
 | GoogleTransliterateTests | Tests/GyaimTests/ | 20 | フィルタ・候補ビルド・セグメント結合・トリガー設定・タイムアウト |
 | ExternalCandidateTests | Tests/GyaimTests/ | 22 | `isValidExternalCandidate` + `buildPrefixCandidates` |
 | PreferencesWindowTests | Tests/GyaimTests/ | 18 | 設定画面UIテスト（トグル存在・初期状態・クリック操作・表示モード切替・淘汰方式） |
@@ -162,7 +163,8 @@ docs/adr/
 ├── 019-gictionary-connection-dict-import.md
 ├── 020-context-conditioned-study.md
 ├── 021-exact-homophone-direct-logprob.md
-└── 022-dictionary-constrained-generation.md
+├── 022-dictionary-constrained-generation.md
+└── 023-hidden-ascii-roman-input-mode.md
 ```
 
 ## Logging & Monitoring
@@ -231,7 +233,7 @@ arXiv:2602.20478 に基づく3階層ドキュメントシステム（ADR-013）�
 
 ### Tier 3: オンデマンド検索 → `docs/adr/`
 
-- `docs/adr/` — 設計判断の経緯（000-022）
+- `docs/adr/` — 設計判断の経緯（000-023）
 
 ### 自動チェック（hooks — `.claude/settings.json`）
 

--- a/GyaimSwift/Resources/Info.plist
+++ b/GyaimSwift/Resources/Info.plist
@@ -33,6 +33,19 @@
 				<key>tsInputModeScriptKey</key>
 				<string>smJapanese</string>
 			</dict>
+			<key>com.apple.inputmethod.Roman</key>
+			<dict>
+				<key>TISInputSourceID</key>
+				<string>com.pitecan.inputmethod.SwiftyGyaim.Roman</string>
+				<key>TISIntendedLanguage</key>
+				<string>en</string>
+				<key>tsInputModeIsVisibleKey</key>
+				<false/>
+				<key>tsInputModePrimaryInScriptKey</key>
+				<true/>
+				<key>tsInputModeScriptKey</key>
+				<string>smRoman</string>
+			</dict>
 		</dict>
 		<key>tsVisibleInputModeOrderedArrayKey</key>
 		<array>

--- a/GyaimSwift/Sources/Gyaim/AppDelegate.swift
+++ b/GyaimSwift/Sources/Gyaim/AppDelegate.swift
@@ -1,3 +1,4 @@
+import Carbon
 import Cocoa
 
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -6,11 +7,33 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         Config.setup()
         Log.config.info("Gyaim launched")
+        Self.enableHiddenRomanInputModeIfNeeded()
 
         // Clipboard polling (60s interval)
         clipboardTimer = Timer.scheduledTimer(withTimeInterval: 60.0, repeats: true) { _ in
             CopyText.set(NSPasteboard.general.string(forType: .string))
         }
+    }
+
+    /// The Roman input mode is hidden from the input menu
+    /// (tsInputModeIsVisibleKey = false), so users cannot enable it in
+    /// System Settings. Enable it here so macOS has an ASCII-capable Gyaim
+    /// mode to fall back to while Secure Event Input is active (issue #85).
+    private static func enableHiddenRomanInputModeIfNeeded() {
+        let romanSourceID = "com.pitecan.inputmethod.SwiftyGyaim.Roman"
+        let filter = [kTISPropertyInputSourceID as String: romanSourceID] as CFDictionary
+        guard let sources = TISCreateInputSourceList(filter, true)?.takeRetainedValue()
+                as? [TISInputSource],
+              let roman = sources.first else {
+            Log.config.error("Roman input mode not found in TIS: \(romanSourceID)")
+            return
+        }
+        if let enabledPtr = TISGetInputSourceProperty(roman, kTISPropertyInputSourceIsEnabled),
+           CFBooleanGetValue(Unmanaged<CFBoolean>.fromOpaque(enabledPtr).takeUnretainedValue()) {
+            return
+        }
+        let status = TISEnableInputSource(roman)
+        Log.config.info("Enabled hidden Roman input mode: status=\(status)")
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/GyaimSwift/Sources/Gyaim/GyaimController.swift
+++ b/GyaimSwift/Sources/Gyaim/GyaimController.swift
@@ -1,3 +1,4 @@
+import Carbon
 import Cocoa
 import InputMethodKit
 
@@ -71,6 +72,19 @@ final class ClipboardMonitor {
 @objc(GyaimController)
 class GyaimController: IMKInputController {
     private static var shared: GyaimController?
+
+    /// Input modes declared in Info.plist ComponentInputModeDict.
+    /// `.roman` is an ASCII-capable passthrough mode that exists so macOS can
+    /// keep Gyaim selectable while Secure Event Input is active (issue #85).
+    /// It is hidden from the input menu (tsInputModeIsVisibleKey = false);
+    /// the system switches to it automatically and back, so users never
+    /// interact with it directly.
+    enum InputMode: String {
+        case japanese = "com.apple.inputmethod.Japanese"
+        case roman = "com.apple.inputmethod.Roman"
+    }
+
+    private var inputMode: InputMode = .japanese
 
     private var inputPat = ""
     private var candidates: [SearchCandidate] = []
@@ -151,6 +165,36 @@ class GyaimController: IMKInputController {
         hideWindow()
         fix(client: sender, skipStudy: true)
         ws?.finish()
+    }
+
+    /// IMK delivers the current input mode via kTextServiceInputModePropertyTag
+    /// on activation and whenever the user (or the system, e.g. Secure Event
+    /// Input fallback) switches modes.
+    override func setValue(_ value: Any!, forTag tag: Int, client sender: Any!) {
+        guard tag == kTextServiceInputModePropertyTag else {
+            super.setValue(value, forTag: tag, client: sender)
+            return
+        }
+        let identifier = value as? String
+        let newMode = Self.inputMode(forTISIdentifier: identifier)
+        guard newMode != inputMode else { return }
+        Log.input.info("Input mode changed: \(identifier ?? "nil") -> \(newMode.rawValue)")
+        if newMode == .roman {
+            // Entering ASCII passthrough: commit any pending preedit first so
+            // it is not lost, then hide the candidate window.
+            if converting {
+                fix(client: sender, skipStudy: true)
+            }
+            hideWindow()
+        }
+        inputMode = newMode
+    }
+
+    /// Pure mapping from the TIS mode identifier to InputMode (testable).
+    /// Unknown identifiers fall back to `.japanese` so a plist/OS mismatch
+    /// never leaves the IME stuck in passthrough.
+    static func inputMode(forTISIdentifier identifier: String?) -> InputMode {
+        identifier.flatMap(InputMode.init(rawValue:)) ?? .japanese
     }
 
     /// AppDelegate.applicationWillTerminate から呼ばれるセーフティネット。
@@ -238,6 +282,12 @@ class GyaimController: IMKInputController {
         let kVirtualJISKanaModeKey: UInt16 = 104
 
         guard event.type == .keyDown else { return false }
+
+        // Roman (英数) passthrough mode: hand every key back to the client so
+        // it is inserted per the active keyboard layout. No conversion here.
+        if inputMode == .roman {
+            return false
+        }
 
         let keyCode = event.keyCode
         let modifierFlags = event.modifierFlags

--- a/GyaimSwift/Tests/GyaimTests/InputModeTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/InputModeTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+/// Tests for the ASCII-capable Roman passthrough mode (issue #85).
+/// The mode itself is hidden from the input menu; these tests cover the
+/// pure identifier→mode mapping used by setValue(_:forTag:client:).
+final class InputModeTests: XCTestCase {
+
+    func testJapaneseIdentifierMapsToJapanese() {
+        XCTAssertEqual(
+            GyaimController.inputMode(forTISIdentifier: "com.apple.inputmethod.Japanese"),
+            .japanese
+        )
+    }
+
+    func testRomanIdentifierMapsToRoman() {
+        XCTAssertEqual(
+            GyaimController.inputMode(forTISIdentifier: "com.apple.inputmethod.Roman"),
+            .roman
+        )
+    }
+
+    func testUnknownIdentifierFallsBackToJapanese() {
+        XCTAssertEqual(
+            GyaimController.inputMode(forTISIdentifier: "com.example.unknown"),
+            .japanese
+        )
+    }
+
+    func testNilIdentifierFallsBackToJapanese() {
+        XCTAssertEqual(GyaimController.inputMode(forTISIdentifier: nil), .japanese)
+    }
+
+    func testInputModeRawValuesMatchInfoPlistModeKeys() {
+        XCTAssertEqual(GyaimController.InputMode.japanese.rawValue, "com.apple.inputmethod.Japanese")
+        XCTAssertEqual(GyaimController.InputMode.roman.rawValue, "com.apple.inputmethod.Roman")
+    }
+}

--- a/docs/adr/023-hidden-ascii-roman-input-mode.md
+++ b/docs/adr/023-hidden-ascii-roman-input-mode.md
@@ -1,0 +1,40 @@
+# ADR-023: 非表示のASCII対応英数モードによるSecure Event Input縮退
+
+## Status
+
+Accepted
+
+## Decision
+
+`Info.plist` の `ComponentInputModeDict` にASCII対応の英数モード `com.apple.inputmethod.Roman`（`smRoman`、言語 `en`、`TISInputSourceID = com.pitecan.inputmethod.SwiftyGyaim.Roman`）を追加する。ただし `tsInputModeIsVisibleKey = false` とし、`tsVisibleInputModeOrderedArrayKey` にも載せず、入力メニューからは見えないフォールバック専用モードとする。
+
+- 非表示モードはシステム設定から有効化できないため、`AppDelegate.applicationDidFinishLaunching` で `TISEnableInputSource` により自動有効化する
+- `GyaimController.setValue(_:forTag:client:)` で `kTextServiceInputModePropertyTag` を受け、Romanモードでは `handle(_:client:)` が即座に `false` を返して全キーをクライアントへパススルーする
+- Romanモードへの切替時、未確定入力があれば `fix(client:sender, skipStudy: true)` で確定してから移行する
+
+## Context
+
+macOSのSecure Event Input（パスワード入力保護）が有効な間、システムはASCII対応の入力ソースしか選択を許可しない。Secure Inputの所有プロセスが終了してもWindowServerにPIDが残留するmacOS側の不具合（issue #85）が起きると、この制限が解除されず、SwiftyGyaimは入力メニューでグレーアウトして選択不能のままになる。
+
+純正日本語IM（Kotoeri）やGoogle日本語入力はASCII対応の英字モードを持つため、Secure Input中はIME内の英字モードへ縮退し、解除後に日本語モードへ自然復帰する。SwiftyGyaimは日本語モード1つしか登録していなかったため、IME全体が選択不能になり症状が際立っていた。
+
+## Consideration
+
+1. **英数モードを可視で追加（Kotoeri方式）** — 標準的だが、入力メニューに「英字」が増えユーザーの認知負荷になる。ユーザーは英数モードの存在を意識させない方針を希望
+2. **英数モードを非表示で追加（採用）** — メニューには従来どおり「Gyaim」1つだけが見える。非表示モードはシステム設定で有効化できないため、起動時の `TISEnableInputSource` が必須。実機検証で `ASCIICapable=true / enabled=true / selectCapable=true` として登録されることを確認済み
+3. **Secure Input検出・診断ログのみ（issue #85の当初案）** — 原因の可視化はできるが症状自体は回避できない。将来の追加改善として残す
+
+なお `TISCreateASCIICapableInputSourceList` はキーボードレイアウトのみを返すため（実機でKotoeri英字モード有効時も `com.apple.keylayout.ABC` のみ）、Secure Input中の実際の縮退挙動の最終確認はTerminalの「安全なキーボード入力」等での実機観察による。自プロセスがSecure Input所有者の場合は選択制限を再現できないことも確認した。
+
+## Consequences
+
+- 良い点: Secure Input発動中・残留時もGyaimがASCII対応モードを持つため、IME全体のグレーアウトを回避できる余地が生まれる。メニュー上のUXは従来と変わらない
+- 良い点: Romanモードはパススルーのみで変換ロジックに影響しない。未知のモードIDは `.japanese` にフォールバックし、パススルーに固着しない
+- 悪い点: 非表示モードの自動有効化はTISの公開APIだが、モード非表示×プログラム的enableの組合せはOSアップデートで挙動が変わるリスクがある
+- 悪い点: Secure Input残留という根本原因（macOS/所有アプリ側のバグ）自体は解決しない。検出・診断ログ（issue #85の残タスク）は別途必要
+
+## References
+
+- Issue #85: Secure Event Input残留時に原因を診断し復旧方法を案内する
+- macSKKでの類似症状: https://github.com/mtgto/macSKK/issues/112
+- mac-akazaでの調査記事: https://blog.64p.org/entry/2026/07/13/044753

--- a/docs/specs/imk-constraints.md
+++ b/docs/specs/imk-constraints.md
@@ -1,7 +1,7 @@
 # Spec: InputMethodKit制約集
 
 > Trigger: GyaimController.swift, AppDelegate.swift, main.swift, CandidateWindow.swift
-> Last updated: 2026-03-17
+> Last updated: 2026-08-09 (Secure Event Input対策の非表示英数モード — ADR-023)
 
 ## 概要
 
@@ -49,3 +49,15 @@ let resolvedClient = (sender as? IMKTextInput) ?? (self.client() as? IMKTextInpu
 ### 8. IMKServer のシングルトン
 
 `main.swift` で作成する `IMKServer` はアプリのライフタイム中1つだけ。GyaimControllerのインスタンスは入力ソースの切り替えごとに再生成される可能性がある。staticプロパティ（`lastConsumedCC`等）はこのため必要。
+
+### 9. Secure Event Input と ASCII対応入力モード（ADR-023）
+
+Secure Event Input（パスワード保護）が有効な間、macOSはASCII対応入力ソースしか選択を許可しない。所有プロセス終了後もWindowServerにPIDが残留するOS側バグ（issue #85）があり、その間ASCII対応モードを持たないIMEは入力メニューでグレーアウトし選択不能になる。
+
+対策として `Info.plist` に非表示（`tsInputModeIsVisibleKey=false`）のASCII対応英数モード `com.apple.inputmethod.Roman` を登録している。
+
+- 非表示モードはシステム設定から有効化できないため、`AppDelegate` 起動時に `TISEnableInputSource` で自動有効化する
+- モード切替は `GyaimController.setValue(_:forTag:client:)`（`kTextServiceInputModePropertyTag`）で受け、Romanモード中は `handle` が `false` を返して全キーパススルー
+- Romanモード切替時に未確定入力があれば `fix(skipStudy: true)` で確定してから移行
+- 他プロセスが所有するSecure Inputは `DisableSecureEventInput()` で解除できない（自プロセスのカウンタにのみ作用）
+- 残留診断: `ioreg -l -w 0 | grep -o 'kCGSSessionSecureInputPID"=[0-9]*'`、復旧は所有アプリの完全終了→ダメなら `Ctrl+Cmd+Q` 画面ロック・解除

--- a/docs/specs/input-flow.md
+++ b/docs/specs/input-flow.md
@@ -1,7 +1,7 @@
 # Spec: キー入力フロー
 
 > Trigger: GyaimController.swift
-> Last updated: 2026-08-03 (生ひらがな候補の文脈過学習抑制 — BUG-030)
+> Last updated: 2026-08-09 (非表示英数モードのパススルー — ADR-023)
 
 ## 概要
 
@@ -56,6 +56,14 @@ AIによる候補生成は通常入力・候補生成時には自動実行しな
 ## Google Transliterate
 
 `GoogleTransliterate.triggerSuffix`（デフォルト `` ` ``）を入力末尾に付けるか、設定画面で登録した Google Transliterate shortcut を押すと、現在の読みをひらがな化して Google Input Tools API に送る。API応答後は `searchMode = 2` として Google候補・ひらがな・カタカナを表示する。suffix入力時は `inputPat` からsuffixを取り除いてから検索し、API応答時に `pendingGoogleQuery` と現在の `inputPat` が一致しない古い結果は破棄する。
+
+## 入力モード（ADR-023）
+
+Info.plistには日本語モードのほか、Secure Event Input対策の非表示ASCII対応英数モード `com.apple.inputmethod.Roman` が登録されている。IMKは `setValue(_:forTag:client:)`（`kTextServiceInputModePropertyTag`）で現在のモードを通知してくる。
+
+- `inputMode == .roman` の間、`handle(_:client:)` は先頭で `false` を返し全キーをクライアントへパススルーする（変換なし）
+- Romanモードへの切替時、未確定入力があれば `fix(client:sender, skipStudy: true)` で確定し、候補ウィンドウを隠す
+- 未知のモードIDは `.japanese` にフォールバックする（`GyaimController.inputMode(forTISIdentifier:)`、InputModeTestsで検証）
 
 ## IMEライフサイクル
 


### PR DESCRIPTION
## 概要

issue #85 の調査で、Secure Event Input残留時にSwiftyGyaimだけがグレーアウトする直接の理由は、**ASCII対応入力モードを1つも持たないこと**だと特定した。Secure Input中、macOSはASCII対応入力ソースしか選択を許可しないため、日本語モードのみのGyaimはIME全体が選択不能になる。純正日本語IM・Google日本語入力は英字モード（ASCII対応）を持つため、Secure Input中はIME内で英字に縮退し解除後に自然復帰する。

本PRはGyaimにも同等の英数モードを追加する。ただし `tsInputModeIsVisibleKey=false` で入力メニューからは隠し、ユーザーには従来どおり「Gyaim」1つだけが見える。

## 変更内容

- **Info.plist**: `com.apple.inputmethod.Roman`（`smRoman` / `en` / `com.pitecan.inputmethod.SwiftyGyaim.Roman`）を非表示モードとして登録
- **AppDelegate**: 非表示モードはシステム設定から有効化できないため、起動時に `TISEnableInputSource` で自動有効化
- **GyaimController**: `setValue(_:forTag:client:)`（`kTextServiceInputModePropertyTag`）でモードを追跡。Romanモード中は `handle` が先頭で `false` を返し全キーをパススルー。Romanモードへの切替時、未確定入力は `fix(skipStudy: true)` で確定
- **docs**: ADR-023、imk-constraints.md（制約9）、input-flow.md（入力モード節）、CLAUDE.md（テスト数・ADR一覧）
- **tests**: InputModeTests 5件（モードIDマッピング・未知IDの `.japanese` フォールバック）

## 検証

- ユニットテスト395件全パス
- 実機（インストール後）でTIS登録を確認: `SwiftyGyaim.Roman` が `ASCIICapable=true / selectCapable=true`、起動時自動有効化で `enabled=true`（無効化→再インストール→起動で再現確認済み）
- `TISCreateASCIICapableInputSourceList` はキーボードレイアウトのみを返すAPIのため、Secure Input中の縮退挙動の最終確認はTerminal「安全なキーボード入力」ONでの実機観察が必要（自プロセスがSecure Input所有者の場合は選択制限が再現しないことを確認済み）

## 残タスク（issue #85のスコープ外）

- Secure Input残留の検出・診断ログ（`IsSecureEventInputEnabled()` + `kCGSSessionSecureInputPID`）と復旧案内UI

Closes #85 ではなく部分対応（診断ログは未実装のためissueは開けたまま）

🤖 Generated with [Claude Code](https://claude.com/claude-code)