### PR TITLE
Secure Event Input残留の診断ログを追加 (issue #85)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Bidirectional romaji-kana conversion with 350+ rules in `rklist`. Includes full-
 ### テスト実行
 
 ```bash
-# ユニットテスト（395テスト）
+# ユニットテスト（404テスト）
 ./Scripts/run-unit-tests.sh
 
 # E2Eテスト（アクセシビリティ権限必要、Gyaimインストール済みの状態で実行）
@@ -105,6 +105,7 @@ xcodebuild -project Gyaim.xcodeproj -scheme GyaimE2ETests -derivedDataPath .buil
 |---------|---------|---------|------|
 | HandleEventTests | Tests/GyaimTests/ | 45 | `routeEvent` 静的メソッドによるキー入力分岐の全網羅 |
 | InputModeTests | Tests/GyaimTests/ | 5 | TISモードID→InputModeマッピング（非表示英数モード、ADR-023） |
+| SecureInputDiagnosticsTests | Tests/GyaimTests/ | 9 | Secure Input残留診断（メッセージ組立・再ログ判定・プロセス名解決） |
 | GoogleTransliterateTests | Tests/GyaimTests/ | 20 | フィルタ・候補ビルド・セグメント結合・トリガー設定・タイムアウト |
 | ExternalCandidateTests | Tests/GyaimTests/ | 22 | `isValidExternalCandidate` + `buildPrefixCandidates` |
 | PreferencesWindowTests | Tests/GyaimTests/ | 18 | 設定画面UIテスト（トグル存在・初期状態・クリック操作・表示モード切替・淘汰方式） |
@@ -169,7 +170,7 @@ docs/adr/
 
 ## Logging & Monitoring
 
-`GyaimLogger.swift` に os.Logger ベースのロギング基盤を実装。デフォルト無効（UserDefaults `loggingEnabled`）。
+`GyaimLogger.swift` に os.Logger ベースのロギング基盤を実装。デフォルト無効（UserDefaults `loggingEnabled`）。例外として `notice` レベル（Secure Event Input残留診断など、稀で診断価値の高いイベント専用）は `loggingEnabled` に関係なく常時 `gyaim.log` へ記録される。
 
 ### カテゴリ
 

--- a/GyaimSwift/Sources/Gyaim/GyaimController.swift
+++ b/GyaimSwift/Sources/Gyaim/GyaimController.swift
@@ -146,6 +146,7 @@ class GyaimController: IMKInputController {
             + "pasteboardCC=\(NSPasteboard.general.changeCount) "
             + "lastConsumedCC=\(GyaimController.lastConsumedCC)")
         CopyText.set(NSPasteboard.general.string(forType: .string))
+        SecureInputDiagnostics.checkAndLog()
         ws?.start()
         showWindow()
     }

--- a/GyaimSwift/Sources/Gyaim/GyaimLogger.swift
+++ b/GyaimSwift/Sources/Gyaim/GyaimLogger.swift
@@ -54,6 +54,16 @@ struct GLogger {
         FileLogger.shared.write(category: category, level: "info", message: msg)
     }
 
+    /// Logs regardless of Log.isEnabled (os_log notice + file).
+    /// Reserved for rare, high-diagnostic-value events (e.g. Secure Event
+    /// Input residue, issue #85) that must leave a trace even when the user
+    /// has logging turned off. Keep the call volume near zero.
+    func notice(_ message: @autoclosure () -> String) {
+        let msg = message()
+        logger.notice("\(msg)")
+        FileLogger.shared.write(category: category, level: "notice", message: msg)
+    }
+
     func warning(_ message: @autoclosure () -> String) {
         guard Log.isEnabled else { return }
         let msg = message()

--- a/GyaimSwift/Sources/Gyaim/SecureInputDiagnostics.swift
+++ b/GyaimSwift/Sources/Gyaim/SecureInputDiagnostics.swift
@@ -1,0 +1,103 @@
+import Carbon
+import Foundation
+import IOKit
+
+/// Secure Event Input残留の診断（issue #85, ADR-023）。
+///
+/// Secure Event Inputが有効な間、キーイベントはIMEをバイパスし日本語変換が
+/// 不能になる。他プロセスが所有するSecure InputをIMEから解除する手段はなく、
+/// 他のIME（Mozc/macSKK等）も検出を実装していないため黙って入力不能になる。
+/// Gyaimは activateServer 到達時に状態を検出し、原因（所有PID・プロセス名・
+/// 生死）と復旧手順をログへ記録して調査時間を短縮する。UIには何も出さない。
+enum SecureInputDiagnostics {
+
+    struct OwnerInfo: Equatable {
+        let pid: pid_t
+        /// nil の場合、所有プロセスはすでに終了している（WindowServer残留）。
+        let processName: String?
+    }
+
+    /// 同一所有者の再ログを抑制する間隔。activateServerはフォーカス移動の
+    /// たびに呼ばれるため、所有者が変わらない限りこの間隔でしか出力しない。
+    static let relogInterval: TimeInterval = 600
+
+    private static var lastLoggedOwnerPID: pid_t?
+    private static var lastLoggedAt: CFAbsoluteTime = 0
+    private static var wasActive = false
+
+    /// activateServer から呼ぶエントリポイント。Secure Inputが無効なら
+    /// Bool判定1回だけで即リターンする（通常パスのコストはほぼゼロ）。
+    static func checkAndLog() {
+        guard IsSecureEventInputEnabled() else {
+            if wasActive {
+                Log.input.notice("Secure Event Input cleared")
+                wasActive = false
+                lastLoggedOwnerPID = nil
+                lastLoggedAt = 0
+            }
+            return
+        }
+        let owner = currentOwner()
+        let now = CFAbsoluteTimeGetCurrent()
+        guard shouldLog(ownerPID: owner?.pid,
+                        lastLoggedOwnerPID: wasActive ? lastLoggedOwnerPID : nil,
+                        elapsedSinceLastLog: now - lastLoggedAt,
+                        firstDetection: !wasActive) else { return }
+        wasActive = true
+        lastLoggedOwnerPID = owner?.pid
+        lastLoggedAt = now
+        Log.input.notice(message(for: owner))
+    }
+
+    /// 再ログ判定（純粋関数、SecureInputDiagnosticsTestsで検証）。
+    static func shouldLog(ownerPID: pid_t?,
+                          lastLoggedOwnerPID: pid_t?,
+                          elapsedSinceLastLog: TimeInterval,
+                          firstDetection: Bool) -> Bool {
+        if firstDetection { return true }
+        if ownerPID != lastLoggedOwnerPID { return true }
+        return elapsedSinceLastLog >= relogInterval
+    }
+
+    /// ログメッセージ組み立て（純粋関数、SecureInputDiagnosticsTestsで検証）。
+    static func message(for owner: OwnerInfo?) -> String {
+        let ownerDescription: String
+        switch owner {
+        case let .some(info) where info.processName != nil:
+            ownerDescription = "pid=\(info.pid) (\(info.processName!))"
+        case let .some(info):
+            ownerDescription = "pid=\(info.pid) (already terminated; stale WindowServer state)"
+        case .none:
+            ownerDescription = "unknown"
+        }
+        return "Secure Event Input is active: owner \(ownerDescription). "
+            + "Key events bypass the IME, so Japanese conversion is unavailable. "
+            + "Recovery: quit the owner app; if it persists, lock the screen "
+            + "(Ctrl+Cmd+Q) and unlock."
+    }
+
+    /// WindowServerが保持する所有PIDをIORegistryから取得し、生死を添える。
+    /// `ioreg -l | grep kCGSSessionSecureInputPID` と同じ情報源。
+    static func currentOwner() -> OwnerInfo? {
+        let root = IORegistryGetRootEntry(kIOMainPortDefault)
+        guard root != MACH_PORT_NULL else { return nil }
+        defer { IOObjectRelease(root) }
+        guard let users = IORegistryEntryCreateCFProperty(
+            root, "IOConsoleUsers" as CFString, kCFAllocatorDefault, 0
+        )?.takeRetainedValue() as? [[String: Any]] else { return nil }
+        for user in users {
+            if let pid = user["kCGSSessionSecureInputPID"] as? pid_t {
+                return OwnerInfo(pid: pid, processName: processName(pid: pid))
+            }
+        }
+        return nil
+    }
+
+    /// PIDからプロセス名を引く。終了済みならnil。
+    static func processName(pid: pid_t) -> String? {
+        var buffer = [CChar](repeating: 0, count: 4096)
+        let length = proc_name(pid, &buffer, UInt32(buffer.count))
+        guard length > 0 else { return nil }
+        return String(cString: buffer)
+    }
+}

--- a/GyaimSwift/Tests/GyaimTests/SecureInputDiagnosticsTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/SecureInputDiagnosticsTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+
+/// Secure Event Input残留診断（issue #85）の純粋ロジック検証。
+/// 実際のIsSecureEventInputEnabled/IORegistry呼び出しはOSセッション状態に
+/// 依存するため、メッセージ組み立てと再ログ判定のみをテストする。
+final class SecureInputDiagnosticsTests: XCTestCase {
+
+    // MARK: - message(for:)
+
+    func testMessageWithAliveOwnerIncludesPIDAndName() {
+        let owner = SecureInputDiagnostics.OwnerInfo(pid: 415, processName: "loginwindow")
+        let msg = SecureInputDiagnostics.message(for: owner)
+        XCTAssertTrue(msg.contains("pid=415 (loginwindow)"))
+        XCTAssertTrue(msg.contains("Ctrl+Cmd+Q"))
+    }
+
+    func testMessageWithTerminatedOwnerMarksStaleState() {
+        let owner = SecureInputDiagnostics.OwnerInfo(pid: 840, processName: nil)
+        let msg = SecureInputDiagnostics.message(for: owner)
+        XCTAssertTrue(msg.contains("pid=840"))
+        XCTAssertTrue(msg.contains("already terminated"))
+    }
+
+    func testMessageWithUnknownOwner() {
+        let msg = SecureInputDiagnostics.message(for: nil)
+        XCTAssertTrue(msg.contains("owner unknown"))
+        XCTAssertTrue(msg.contains("Secure Event Input is active"))
+    }
+
+    // MARK: - shouldLog(...)
+
+    func testFirstDetectionAlwaysLogs() {
+        XCTAssertTrue(SecureInputDiagnostics.shouldLog(
+            ownerPID: 415, lastLoggedOwnerPID: nil,
+            elapsedSinceLastLog: 0, firstDetection: true))
+    }
+
+    func testSameOwnerWithinIntervalDoesNotRelog() {
+        XCTAssertFalse(SecureInputDiagnostics.shouldLog(
+            ownerPID: 415, lastLoggedOwnerPID: 415,
+            elapsedSinceLastLog: 5, firstDetection: false))
+    }
+
+    func testOwnerChangeRelogsImmediately() {
+        XCTAssertTrue(SecureInputDiagnostics.shouldLog(
+            ownerPID: 999, lastLoggedOwnerPID: 415,
+            elapsedSinceLastLog: 5, firstDetection: false))
+    }
+
+    func testSameOwnerRelogsAfterInterval() {
+        XCTAssertTrue(SecureInputDiagnostics.shouldLog(
+            ownerPID: 415, lastLoggedOwnerPID: 415,
+            elapsedSinceLastLog: SecureInputDiagnostics.relogInterval + 1,
+            firstDetection: false))
+    }
+
+    // MARK: - processName(pid:)
+
+    func testProcessNameForCurrentProcess() {
+        let name = SecureInputDiagnostics.processName(pid: getpid())
+        XCTAssertNotNil(name)
+        XCTAssertFalse(name!.isEmpty)
+    }
+
+    func testProcessNameForTerminatedPIDReturnsNil() {
+        // PID 99999台の空きを探す確実な方法はないが、負のPIDは常に無効
+        XCTAssertNil(SecureInputDiagnostics.processName(pid: -1))
+    }
+}

--- a/docs/specs/imk-constraints.md
+++ b/docs/specs/imk-constraints.md
@@ -1,7 +1,7 @@
 # Spec: InputMethodKit制約集
 
 > Trigger: GyaimController.swift, AppDelegate.swift, main.swift, CandidateWindow.swift
-> Last updated: 2026-08-09 (Secure Event Input対策の非表示英数モード — ADR-023)
+> Last updated: 2026-08-10 (Secure Input残留の診断ログ — issue #85)
 
 ## 概要
 
@@ -61,3 +61,4 @@ Secure Event Input（パスワード保護）が有効な間、macOSはASCII対�
 - Romanモード切替時に未確定入力があれば `fix(skipStudy: true)` で確定してから移行
 - 他プロセスが所有するSecure Inputは `DisableSecureEventInput()` で解除できない（自プロセスのカウンタにのみ作用）
 - 残留診断: `ioreg -l -w 0 | grep -o 'kCGSSessionSecureInputPID"=[0-9]*'`、復旧は所有アプリの完全終了→ダメなら `Ctrl+Cmd+Q` 画面ロック・解除
+- **重要**: 英数モードがあってもSecure Input中はキーイベント自体がIMEをバイパスするため、日本語変換不能は防げない（loginwindow残留の実機で確認）。IMEにできるのは検出とログのみ。`SecureInputDiagnostics.checkAndLog()`（activateServerで呼出）が所有PID・プロセス名を `notice` で常時ログする。他IME（Mozc/macSKK）はSecure Input対応コードを持たず黙って入力不能になる

--- a/docs/specs/input-flow.md
+++ b/docs/specs/input-flow.md
@@ -1,7 +1,7 @@
 # Spec: キー入力フロー
 
 > Trigger: GyaimController.swift
-> Last updated: 2026-08-09 (非表示英数モードのパススルー — ADR-023)
+> Last updated: 2026-08-10 (Secure Input残留の診断ログ — issue #85)
 
 ## 概要
 
@@ -68,9 +68,11 @@ Info.plistには日本語モードのほか、Secure Event Input対策の非表�
 ## IMEライフサイクル
 
 ```
-activateServer(_:) → 辞書start, クリップボード取得, showWindow
+activateServer(_:) → クリップボード取得, Secure Input診断, 辞書start, showWindow
 deactivateServer(_:) → hideWindow, fix(skipStudy: true), 辞書finish
 ```
+
+`SecureInputDiagnostics.checkAndLog()` はSecure Event Inputが有効なとき、所有PID・プロセス名（終了済みなら stale と明記）・復旧手順を `notice` レベルで記録する。`notice` は `loggingEnabled` に関係なく常時 `gyaim.log` へ書かれる（再発が稀で予期できないため）。同一所有者は10分間隔でしか再出力しない。
 
 **重要**: deactivationではsenderをfix()に渡すこと。渡さないとクライアント取得に失敗しテキストが破棄される（Issue #13で修正済み）。
 


### PR DESCRIPTION
## 概要

PR #86（英数モード）マージ後の再発（所有者: loginwindow、生存プロセス）で、**Secure Input中はキーイベント自体がIMEをバイパスするため、入力モードでは日本語変換不能を防げない**ことが確認された。他プロセス所有のSecure Inputを解除するAPIは存在せず、Mozc・macSKKも検出コードを一切持たない（コード検索で0件確認）。

そこでissue #85の元々の動機である「原因が見えず調査に時間がかかる」を解決する。**UIには何も出さず**、activateServer到達時に検出してログへ記録するだけの、IMEとして最も控えめな形にした。

## 変更内容

- **SecureInputDiagnostics.swift**: `IsSecureEventInputEnabled()` で検出し、IORegistry（`IOConsoleUsers` の `kCGSSessionSecureInputPID`、`ioreg` と同じ情報源）から所有PIDを取得。`proc_name` でプロセス名を解決し、終了済みなら「already terminated; stale WindowServer state」と明記。復旧手順（所有アプリ終了→ `Ctrl+Cmd+Q` ロック・解除）もログ1行に含める
- **GLogger.notice**: `loggingEnabled` に関係なく常時 `gyaim.log` へ書く新レベル。残留は稀で予期できず、そのときログがOFFなら価値がないため。同一所有者の再ログは10分間隔に抑制（activateServerはフォーカス移動ごとに呼ばれる）
- Secure Inputが解除された最初のactivateで「Secure Event Input cleared」も記録

## ログ例（実機で捕捉した実例）

```
[2026-08-10 09:40:49] [input] [notice] Secure Event Input is active: owner pid=843 (Google Chrome). Key events bypass the IME, so Japanese conversion is unavailable. Recovery: quit the owner app; if it persists, lock the screen (Ctrl+Cmd+Q) and unlock.
```

（検証中にChromeがパスワード欄で実際にSecure Inputを保持し、それを正しく捕捉した）

## 検証

- ユニットテスト404件全パス（SecureInputDiagnosticsTests 9件追加: メッセージ組立・再ログ判定・プロセス名解決）
- 実機: 上記ログ例のとおり、実際の保持者を所有者名付きで記録

🤖 Generated with [Claude Code](https://claude.com/claude-code)