### PR TITLE
コントローラinitでの共有接続辞書リセットを廃止 (BUG-033)

### DIFF
--- a/.claude/skills/install-ime/SKILL.md
+++ b/.claude/skills/install-ime/SKILL.md
@@ -13,7 +13,7 @@ SwiftyGyaimをビルド → インストール → MD5検証する手順。
 ### Step 1: Build
 
 ```bash
-xcodebuild -project /PATH/GyaimSwift/Gyaim.xcodeproj -scheme Gyaim -configuration Debug -derivedDataPath /PATH/GyaimSwift/.build build 2>&1 | tail -3
+xcodebuild -project /PATH/GyaimSwift/Gyaim.xcodeproj -scheme Gyaim -configuration Release -derivedDataPath /PATH/GyaimSwift/.build build 2>&1 | tail -3
 ```
 
 ビルド失敗時はここで止める。
@@ -29,13 +29,13 @@ echo "done"
 
 ```bash
 rm -rf ~/Library/Input\ Methods/SwiftyGyaim.app
-cp -r /PATH/GyaimSwift/.build/Build/Products/Debug/SwiftyGyaim.app ~/Library/Input\ Methods/
+cp -r /PATH/GyaimSwift/.build/Build/Products/Release/SwiftyGyaim.app ~/Library/Input\ Methods/
 ```
 
 ### Step 4: Verify with MD5
 
 ```bash
-md5 ~/Library/Input\ Methods/SwiftyGyaim.app/Contents/MacOS/SwiftyGyaim /PATH/GyaimSwift/.build/Build/Products/Debug/SwiftyGyaim.app/Contents/MacOS/SwiftyGyaim
+md5 ~/Library/Input\ Methods/SwiftyGyaim.app/Contents/MacOS/SwiftyGyaim /PATH/GyaimSwift/.build/Build/Products/Release/SwiftyGyaim.app/Contents/MacOS/SwiftyGyaim
 ```
 
 MD5が一致することを確認。
@@ -49,6 +49,9 @@ ps aux | grep -i SwiftyGyaim | grep -v grep
 新しいプロセスが起動していることを確認（タイムスタンプがビルド時刻以降）。
 
 ## Notes
+
+- **必ずRelease構成でインストールすること**。Debugビルド（-Onone）は辞書検索が3〜4倍遅く（prefix検索 実測33ms→127ms）、「変換が遅い」体感退行になる（2026-08-10に発生）。Debugは開発時のユニットテスト用
+
 
 - `/PATH/` はリポジトリルート（`/Users/tanabe.nobuyuki/Documents/repositories/SwiftyGyaim`）に置換
 - IMEはmacOSが自動的に再起動するので手動起動不要

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,13 +31,13 @@ Gyaim is a Japanese Input Method Editor (IME) for macOS. Originally created by T
 # Generate Xcode project
 xcodegen generate
 
-# Build
-xcodebuild -project Gyaim.xcodeproj -scheme Gyaim -configuration Debug -derivedDataPath .build build
+# Build（インストール用は必ずRelease。Debugは辞書検索が3〜4倍遅く体感退行する）
+xcodebuild -project Gyaim.xcodeproj -scheme Gyaim -configuration Release -derivedDataPath .build build
 
 # Install
 killall SwiftyGyaim
 rm -rf ~/Library/Input\ Methods/SwiftyGyaim.app
-cp -r .build/Build/Products/Debug/SwiftyGyaim.app ~/Library/Input\ Methods/
+cp -r .build/Build/Products/Release/SwiftyGyaim.app ~/Library/Input\ Methods/
 ```
 
 Working directory for build commands: `GyaimSwift/`
@@ -92,7 +92,7 @@ Bidirectional romaji-kana conversion with 350+ rules in `rklist`. Includes full-
 ### テスト実行
 
 ```bash
-# ユニットテスト（395テスト）
+# ユニットテスト（396テスト）
 ./Scripts/run-unit-tests.sh
 
 # E2Eテスト（アクセシビリティ権限必要、Gyaimインストール済みの状態で実行）
@@ -111,7 +111,7 @@ xcodebuild -project Gyaim.xcodeproj -scheme GyaimE2ETests -derivedDataPath .buil
 | CandidateWindowTests | Tests/GyaimTests/ | 26 | 表示モード（リスト/クラシック）の切替・描画・最大候補数・位置計算 |
 | CopyTextTests | Tests/GyaimTests/ | 7 | CopyText ファイルI/O + NSPasteboard.changeCount |
 | RomaKanaTests | Tests/GyaimTests/ | 18 | ローマ字⇔かな変換の双方向テスト |
-| WordSearchTests | Tests/GyaimTests/ | 48 | 辞書検索（前方一致・完全一致・登録・トリガーサフィックス・study・eviction・削除・ソースタグ） |
+| WordSearchTests | Tests/GyaimTests/ | 49 | 辞書検索（前方一致・完全一致・登録・トリガーサフィックス・study・eviction・削除・ソースタグ） |
 | ContextDictTests | Tests/GyaimTests/ | 8 | 文脈条件付き学習（contextKey・suffix一致・affinity・永続化・削除・上限） |
 | StudyEntryTests | Tests/GyaimTests/ | 9 | StudyEntryスコア計算・EvictionMode・ファイルI/O |
 | CryptTests | Tests/GyaimTests/ | 6 | 暗号化/復号のラウンドトリップ |

--- a/GyaimSwift/Sources/Gyaim/GyaimController.swift
+++ b/GyaimSwift/Sources/Gyaim/GyaimController.swift
@@ -124,7 +124,11 @@ class GyaimController: IMKInputController {
         }
 
         if ws == nil {
-            reloadConnectionDictionary()
+            // 新規コントローラは共有キャッシュを再利用するだけ。ここで
+            // resetConnectionDict() を呼ぶとIMKのコントローラ再生成（アプリ
+            // 切替のたび）ごとに40K行の再パースが走り、PR #83の共有が
+            // 無効化される（BUG-033）。
+            setupWordSearch()
         }
         Log.input.info("GyaimController initialized")
 
@@ -204,19 +208,22 @@ class GyaimController: IMKInputController {
         shared?.ws?.finish()
     }
 
+    /// 明示リロード（Gictionaryインポート後など）。同じパスへ新しい内容が
+    /// 書き込まれるため、共有キャッシュを破棄してから作り直す。
+    /// コントローラinitからは呼ばないこと（BUG-033）。
     static func reloadConnectionDictionary() {
-        shared?.reloadConnectionDictionary()
+        WordSearch.resetConnectionDict()
+        shared?.setupWordSearch()
     }
 
-    private func reloadConnectionDictionary() {
+    /// WordSearchを構築する。共有ConnectionDictはパスが同じ限り再利用され、
+    /// プロセス内の初回だけロードが走る。
+    private func setupWordSearch() {
         guard let bundleDictPath = Bundle.main.path(forResource: "dict", ofType: "txt") else {
             Log.input.error("dict.txt not found in bundle")
             return
         }
         let dictPath = Config.activeConnectionDictFile(bundleDictPath: bundleDictPath)
-        // Explicit reload (e.g. after a Gictionary import) rewrites the same
-        // path, so the shared cache must be dropped or the old content stays.
-        WordSearch.resetConnectionDict()
         ws = WordSearch(connectionDictFile: dictPath,
                         localDictFile: Config.localDictFile,
                         studyDictFile: Config.studyDictFile)

--- a/GyaimSwift/Tests/GyaimTests/WordSearchTests.swift
+++ b/GyaimSwift/Tests/GyaimTests/WordSearchTests.swift
@@ -37,6 +37,22 @@ final class WordSearchTests: XCTestCase {
         try? FileManager.default.removeItem(at: tempDir)
     }
 
+    /// BUG-033: コントローラ再生成のたびに共有ConnectionDictが破棄され、
+    /// アプリ切替ごとに40K行の再パースが走っていた回帰の防止。
+    /// 同じパスでWordSearchを作り直しても共有インスタンスが再利用されること。
+    func testInitReusesSharedConnectionDictForSamePath() throws {
+        try XCTSkipIf(ws == nil)
+        let first = try XCTUnwrap(WordSearch.sharedConnectionDict)
+        let second = WordSearch(
+            connectionDictFile: WordSearch.sharedConnectionDictFile,
+            localDictFile: tempDir.appendingPathComponent("localdict.txt").path,
+            studyDictFile: tempDir.appendingPathComponent("studydict.txt").path)
+        _ = second
+        let after = try XCTUnwrap(WordSearch.sharedConnectionDict)
+        XCTAssertTrue(first === after,
+                      "同一パスの再initで共有ConnectionDictが再ロードされている")
+    }
+
     func testSearchPrefix() throws {
         try XCTSkipIf(ws == nil)
         let results = ws.search(query: "man", searchMode: 0)

--- a/docs/specs/bug-memory.md
+++ b/docs/specs/bug-memory.md
@@ -1,7 +1,7 @@
 # Spec: バグメモリ
 
 > Trigger: 全ファイル（デバッグ時に参照）
-> Last updated: 2026-08-03 (BUG-031追加)
+> Last updated: 2026-08-10 (BUG-033追加)
 
 ## 概要
 
@@ -383,6 +383,16 @@
 - **修正**: BUG-024と同じ構造的解決。`exactHomophoneCandidateIndices` で記号のみ候補（かな・漢字を1文字も含まない）を比較集合から無条件に除外。bestが記号の場合は `indices.contains(best)` ガードにより比較自体がスキップされ、challengerとしても昇格不能になる。
 - **検証**: `ZenzRuntimeTests.testExactHomophoneCandidateIndicesExcludesSymbolOnlyCandidates`（maru実データ再現）、`testExactHomophoneCandidateIndicesKeepsMixedSymbolKanjiCandidates`（〇円のような混在テキストは比較に残る）。
 - **教訓**: 文字レベルLMのスコアが信頼できない候補クラス（かな列=過大、記号=過小）は、margin調整ではなく**比較集合から構造的に除外**する。また「ユーザーが同じ修正を短時間に繰り返している」パターンはログ上で最優先の改善シグナル——学習が効いていない箇所を直接指している。
+
+### BUG-033: コントローラinitの無条件resetで接続辞書の共有が無効化
+
+- **発見日**: 2026-08-10
+- **症状**: 「変換が遅くなった」調査中に、`ConnectionDict loaded: 40904 entries`（Release約90ms/Debug約190ms）がアプリ切替のたびに記録されていることを発見。30秒間に3回再ロードすることもあった。PR #83で接続辞書をプロセス共有にしたはずなのに効いていない。
+- **影響**: アプリ/入力フィールド切替直後の初回変換が辞書再パース分（約90〜190ms）遅延。共有前と同じ状態。
+- **原因**: `GyaimController.init` → `reloadConnectionDictionary()` が**無条件に** `WordSearch.resetConnectionDict()` を呼んでいた。resetはGictionaryインポート（同一パスへの上書き）用なのに、IMKがクライアントごとに再生成するコントローラのinitパスに置かれていたため、生成のたびに共有キャッシュが破棄→再ロード。
+- **修正**: init用の `setupWordSearch()`（resetなし、パス一致なら共有再利用）と、明示リロード用の `static reloadConnectionDictionary()`（reset+setup、PreferencesWindowのインポート後にのみ呼ぶ）に分離。
+- **検証**: `WordSearchTests.testInitReusesSharedConnectionDictForSamePath`（同一パス再initで共有インスタンスの同一性を確認）
+- **教訓**: 「キャッシュ+明示invalidate」を導入するときは、invalidateが**通常パス（init等）から呼ばれていないか**を必ず確認する。ログの `loaded` 行の頻度が共有の実効性を直接示す——共有導入時はログ頻度の before/after を検証に含めること。また、性能退行の調査はまずログの実測値（PerfLog）を新旧期間で比較するのが最短。
 
 ## パターン集
 

--- a/docs/specs/dictionary-system.md
+++ b/docs/specs/dictionary-system.md
@@ -1,7 +1,7 @@
 # Spec: 辞書システム
 
 > Trigger: WordSearch.swift, ConnectionDict.swift
-> Last updated: 2026-08-03 (接続辞書のプロセス内共有)
+> Last updated: 2026-08-10 (共有キャッシュのreset誤用を修正 — BUG-033)
 
 ## 概要
 
@@ -312,6 +312,7 @@ OFF時は単一パス（study → local → connection）で従来どおり MRU 
 
 - init() は `connectionDictFile` パスが一致すればキャッシュを再利用し、変わった場合のみロード
 - **明示リロードは `resetConnectionDict()` を先に呼ぶこと**: Gictionaryインポートは同じパス（`~/.gyaim/connectiondict.txt`）へ新しい内容を書くため、パスキーのキャッシュ判定だけでは反映されない。`GyaimController.reloadConnectionDictionary()` がこれを行う
+- **`resetConnectionDict()` を通常パス（コントローラinit等）から呼ばないこと**: initから毎回呼ぶと共有が無効化され、コントローラ再生成のたびに再ロードが走る（BUG-033で実際に発生。`GyaimController` はinit用 `setupWordSearch()` と明示リロード用 `static reloadConnectionDictionary()` を分離している）
 - studyDict と同様、スレッドはIMKのメインスレッド前提（ロックなし）
 
 ## 既知の制約


### PR DESCRIPTION
## 概要

「変換が遅くなった」報告の調査で2つの問題を特定した。

### 1. 直接原因: Debugビルドのインストール（コード変更なしで対処）

install-imeスキル/CLAUDE.mdの手順がDebug構成だったため、最適化なし（-Onone）のバイナリがインストールされていた。prefix検索の実測: Release 32.7ms（100ms超 0%）→ Debug 119.7ms（100ms超 80%）。手順をRelease構成に変更し、スキルに警告を追記。

### 2. 潜在バグ: PR #83 の辞書共有が無効化されていた（BUG-033）

`GyaimController.init` が毎回 `WordSearch.resetConnectionDict()` を呼ぶため、共有キャッシュがコントローラ再生成（IMKはクライアントごとに再生成＝アプリ切替のたび）のたびに破棄→40K行再パース。ログで30秒間に3回の `ConnectionDict loaded` を確認。resetはGictionaryインポート（同一パス上書き）専用のはずだった。

## 変更内容

- init用 `setupWordSearch()`（resetなし。パス一致なら共有再利用）と明示リロード用 `static reloadConnectionDictionary()`（reset+再構築。PreferencesWindowのインポート後のみ）に分離
- 回帰テスト `testInitReusesSharedConnectionDictForSamePath` 追加（同一パス再initで共有インスタンスの同一性を検証）
- install-ime スキル / CLAUDE.md のビルド・インストール手順を Release に変更
- bug-memory.md に BUG-033 追記、dictionary-system.md に「resetを通常パスから呼ばない」制約を明記

## 検証

- ユニットテスト396件全パス
- Release再インストール後の実測: prefix検索 avg 36.3ms・100ms超 0%（8/7の基線32.7msと同水準）

## 注意

CLAUDE.md のテスト数はPR #87（404件）と競合するため、後にマージする側で合算（405件）に直す必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)